### PR TITLE
WIP: Update drushrc.php to use an absolute path to root

### DIFF
--- a/tasks/install.xml
+++ b/tasks/install.xml
@@ -18,9 +18,6 @@
                 </replacetokens>
             </filterchain>
         </copy>
-        
-        <!-- Copy the drush alias script -->
-        <copy file="${vagrant.bin.source}/drush" tofile="${vagrant.bin.dest}/drush"/>
 
         <!-- Copy the build configuration. -->
         <mkdir dir="${application.startdir}/conf" />


### PR DESCRIPTION
Modify the drushrc.php file so that it uses an absolute path instead of a relative one. This allows us to use a drush (with an alias) anywhere inside the Drupal root.
