### PR TITLE
Create a symlink for Javascript files

### DIFF
--- a/tasks/styleguide.xml
+++ b/tasks/styleguide.xml
@@ -324,5 +324,4 @@
         <symlink target="${js_source}" link="${js_dest}" />
     </target>
 
-
 </project>


### PR DESCRIPTION
This pull request creates a symlink to the styleguide's js folder in order to use these scripts on the Drupal site.
