### PR TITLE
Private file path creation

### DIFF
--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -203,9 +203,6 @@
                 <delete dir="${drupal.settings.file_private_path.resolved}" />
                 <mkdir dir="${drupal.settings.file_private_path.resolved}" mode="777" />
             </then>
-            <else>
-                <echo>${placeholder_for} already exists.</echo>
-            </else>
         </if>
         
         <drush command="site-install" assume="yes">


### PR DESCRIPTION
If the private file path is set then we should create it in such a way that drupal can manipulate it and create the necessary .htaccess file.
