### PR TITLE
Suggestions: Do not use --sites-subdir=default

### DIFF
--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -212,7 +212,6 @@
 
         <drush command="site-install" assume="yes">
             <option name="site-name">${drupal.site_name}</option>
-            <option name="sites-subdir">${drupal.sites_subdir}</option>
             <option name="account-name">admin</option>
             <option name="account-pass">admin</option>
             <param>${drupal.profile}</param>


### PR DESCRIPTION
If we are not doing multisite, adding --sites-subdir="default" to the drush command  is unnecessary  and it adds an extraneous web/sites/sites.php to the codebase. By adding sites.php we are opting in to multisite, and that's probably not intended. 

@see https://www.drupal.org/node/1792924
