### PR TITLE
Fix for Drupal installing in 'web' instead of 'docroot' in the build artifact

### DIFF
--- a/tasks/lib/artifacts.xml
+++ b/tasks/lib/artifacts.xml
@@ -40,7 +40,7 @@
                 -->
             <filterchain>
                 <replaceregexp>
-                    <regexp pattern="web(/.+type:drupal-)" replace="docroot\1" />
+                    <regexp pattern="web(/[^\]]+type:drupal-)" replace="docroot\1" />
                 </replaceregexp>
             </filterchain>
         </copy>


### PR DESCRIPTION
This regex broke when the composer installer arrays are reformatted to use multiple lines.

This is specifically relevant for acquia deployment... this bug will affect you if your `composer.json` says

```
    "extra": {
        "installer-paths": {
            "web/core": [
                "type:drupal-core"
            ],
            "web/modules/contrib/{$name}": [
                "type:drupal-module"
            ],
            ...
```

instead of 

```
    "extra": {
        "installer-paths": {
            "web/core": [ "type:drupal-core" ],
            "web/modules/contrib/{$name}": [ "type:drupal-module" ],
            ...
```
