### PR TITLE
Fix dependency on global composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,12 @@
         }
     ],
     "require": {
-        "phing/phing": "^2.14",
+        "composer/composer": "^1.2",
         "continuousphp/phing-drush-task": "dev-master",
         "drupal/coder": "^8.2",
-        "phpmd/phpmd" : "^2.4",
         "nilportugues/php_todo": "^1.0",
-        "pear/versioncontrol_git": "@dev"
+        "pear/versioncontrol_git": "@dev",
+        "phing/phing": "^2.14",
+        "phpmd/phpmd": "^2.4"
     }
 }

--- a/tasks/lib/artifacts.xml
+++ b/tasks/lib/artifacts.xml
@@ -75,7 +75,7 @@
         <!--
             then we composer install in the build dir...
             -->
-        <exec command="composer install --no-dev" dir="${install_dir}" checkreturn="true" />
+        <exec command="vendor/bin/composer install --no-dev" dir="${install_dir}" checkreturn="true" />
 
         <!--
             having git repositories in the vendor dir messes up the build


### PR DESCRIPTION
I don't think this is the right way to solve this. Instead, we should use the [ComposerTask](https://www.phing.info/docs/master/hlhtml/index.html#ComposerTask), which allows you to set the path to composer if necessary (we could set it up to work like the DrushTask, which allows you to set the `drush.bin` property).

See issue #23.