### PR TITLE
Copy /drush directory to the artifact

### DIFF
--- a/tasks/lib/artifacts.xml
+++ b/tasks/lib/artifacts.xml
@@ -71,6 +71,16 @@
             <filelist dir="${build.dir}" listfile="${tmpfile}" />
         </copy>
         <delete file="${tmpfile}" />
+        
+        <!--
+            AND we need to copy the top level /drush directory
+            -->
+        <tempfile property="tmpfile" destdir="${build.dir}/artifacts" />
+        <exec command="git ls-files drush" dir="${build.dir}" output="${tmpfile}" />
+        <copy todir="${install_dir}" overwrite="true" haltonerror="true">
+            <filelist dir="${build.dir}" listfile="${tmpfile}" />
+        </copy>
+        <delete file="${tmpfile}" />
 
         <!--
             then we composer install in the build dir...


### PR DESCRIPTION
The /drush directory is the preferred place to put Drush config/commandfiles/aliases since it gets read automatically by Drush when you are inside and outside the container. Its a convention worth embracing.

My VM is not functioning right now so this is untested. My deepest apologies. This "should work". I thank you for testing and correcting any silly errors I have made.