### PR TITLE
Add memcache config for Drupal

### DIFF
--- a/conf/drupal/settings.acquia.php
+++ b/conf/drupal/settings.acquia.php
@@ -20,18 +20,10 @@ $settings['trusted_host_patterns'] = array(
 if (file_exists('/var/www/site-php')) {
   require '/var/www/site-php/${acquia.accountname}/${acquia.accountname}-settings.inc';
 
-  // Acquia is in the process of upgrading their platform-provided memcache. In
-  // the meantime, use the old $conf vars for the memcache configuration.
-  // @see https://docs.acquia.com/article/drupal-8-cache-backend
-  // @see https://docs.acquia.com/cloud/performance/memcached
-  if (empty($settings['memcache']['servers'])) {
-    $settings['memcache']['servers'] = $conf['memcache_servers'];
-    $settings['memcache']['key_prefix'] = $conf['memcache_key_prefix'];
-    $settings['memcache']['bins'] = ['default' => 'default'];
-  }
-
   // Use memcache as the default cache backend.
-  $settings['cache']['default'] = 'cache.backend.memcache';
+  // @see https://docs.acquia.com/cloud/performance/memcached
+  // Uncomment this **after** the site is installed.
+  // $settings['cache']['default'] = 'cache.backend.memcache';
 }
 
 // Use our own config sync directory.

--- a/conf/drupal/settings.acquia.php
+++ b/conf/drupal/settings.acquia.php
@@ -19,6 +19,19 @@ $settings['trusted_host_patterns'] = array(
 // Include the Acquia database connection and other config.
 if (file_exists('/var/www/site-php')) {
   require '/var/www/site-php/${acquia.accountname}/${acquia.accountname}-settings.inc';
+
+  // Acquia is in the process of upgrading their platform-provided memcache. In
+  // the meantime, use the old $conf vars for the memcache configuration.
+  // @see https://docs.acquia.com/article/drupal-8-cache-backend
+  // @see https://docs.acquia.com/cloud/performance/memcached
+  if (empty($settings['memcache']['servers'])) {
+    $settings['memcache']['servers'] = $conf['memcache_servers'];
+    $settings['memcache']['key_prefix'] = $conf['memcache_key_prefix'];
+    $settings['memcache']['bins'] = ['default' => 'default'];
+  }
+
+  // Use memcache as the default cache backend.
+  $settings['cache']['default'] = 'cache.backend.memcache';
 }
 
 // Use our own config sync directory.

--- a/conf/drupal/settings.php
+++ b/conf/drupal/settings.php
@@ -11,6 +11,15 @@ $databases['default']['default'] = array(
   'collation' => 'utf8mb4_general_ci',
 );
 
+// Memcache configuration.
+$settings['memcache']['servers'] = ['127.0.0.1:11211' => 'default'];
+$settings['memcache']['bins'] = ['default' => 'default'];
+$settings['memcache']['key_prefix'] = '';
+
+// Use memcache as the default cache backend.
+// Uncomment this **after** the site is installed.
+// $settings['cache']['default'] = 'cache.backend.memcache';
+
 $config_directories = array();
 $config_directories[CONFIG_SYNC_DIRECTORY] = '${drupal.config_sync_directory}';
 


### PR DESCRIPTION
The problem here is that you can only enable the memcache cache backend after Drupal is installed... and when the memcache module is present and enabled. So these settings.php changes will cause problems on Acquia if memcache isn't present, and even locally you have to manually edit the `settings.php` file after site installation to use memcache, which is not going to be a consistent way of enabling that config.