### PR TITLE
Allow codesniffer to sniff symlinked files.

### DIFF
--- a/tasks/code_review/drupal_code_sniffer.xml
+++ b/tasks/code_review/drupal_code_sniffer.xml
@@ -22,7 +22,7 @@
             verbosity="1">
 
             <!-- Drupal code -->
-            <fileset dir="${build.dir}/${drupal.root}" includesfile="${drupal_code_sniffer.files}" />
+            <fileset dir="${build.dir}/${drupal.root}" includesfile="${drupal_code_sniffer.files}" expandsymboliclinks="true" />
 
         </phpcodesniffer>
     </target>


### PR DESCRIPTION
Ran into this on RFF, where we have our modules directory symlinked into the webroot because of the way composer and d7 work together.