### PR TITLE
Fix out of memory errors when pushing an artifact during deployment

### DIFF
--- a/tasks/lib/repositories.xml
+++ b/tasks/lib/repositories.xml
@@ -220,7 +220,7 @@ ${modified_files}
         <fail unless="repo.branch" />
 
         <!-- If the local repository has forward commits, push them. -->
-        <exec command="git diff origin/${repo.branch}" dir="${repo.dir}" outputProperty="has_forward_commits" />
+        <exec command="git cherry origin/${repo.branch}" dir="${repo.dir}" outputProperty="has_forward_commits" />
 
         <if>
             <not><istrue value="${has_forward_commits}" /></not>


### PR DESCRIPTION
You've probably seen out of memory errors like this during some deployments:

> repositories > push:
>
> PHP Fatal error:  Allowed memory size of 268435456 bytes exhausted (tried to allocate 48 bytes) in /var/www/rff.local/vendor/phing/phing/classes/phing/tasks/system/ExecTask.php on line 295
>
> Fatal error: Allowed memory size of 268435456 bytes exhausted (tried to allocate 48 bytes) in /var/www/rff.local/vendor/phing/phing/classes/phing/tasks/system/ExecTask.php on line 295


This was happening when attempting to push large changesets, because the-build was attempting to output the entire diff into a variable when it was checking whether there were any changes to push. OOPS.

To test:

* Basically you have to run a big deployment -- like the first one, or one where you add or remove a LOT of code.
* But also normal deployments should continue to work.

Should I create patch releases of older versions, for projects that are using previous versions of the-build and don't want to update to the latest?