### PR TITLE
The drupal/coder package version changed with the switch to packages.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,19 @@
         "bin/the-build-installer"
     ],
     "require": {
-        "phing/phing": "^2.14",
         "continuousphp/phing-drush-task": "dev-master",
         "drupal/coder": "*",
+        "pear/versioncontrol_git": "@dev",
+        "phing/phing": "^2.14",
         "phpmd/phpmd" : "^2.4",
-        "nilportugues/php_todo": "^1.0",
-        "pear/versioncontrol_git": "@dev"
+        "nilportugues/php_todo": "^1.0"
     },
     "autoload": {
         "psr-0": {
             "TheBuild\\": "src/"
         }
+    },
+    "config": {
+        "sort-packages": "true"
     }
 }


### PR DESCRIPTION
…drupal.org/8.

I'm not sure if this will cause problems for existing projects that use coder review without explicitly requiring `drupal/coder`.