### PR TITLE
Add the Acquia temporary directory location

### DIFF
--- a/conf/drupal/settings.acquia.php
+++ b/conf/drupal/settings.acquia.php
@@ -8,13 +8,16 @@ $settings['hash_salt'] = '${drupal.hash_salt}';
 $settings['update_free_access'] = FALSE;
 $settings['container_yamls'][] = __DIR__ . '/services.yml';
 
-$settings['file_public_path'] = 'files';
-$settings['file_private_path'] = "/mnt/files/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/files-private";
-
 $settings['trusted_host_patterns'] = array(
   '^${acquia.accountname}dev.prod.acquia-sites.com',
   '^${acquia.accountname}stg.prod.acquia-sites.com',
 );
+
+$settings['file_public_path'] = 'files';
+$settings['file_private_path'] = "/mnt/files/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/files-private";
+
+// Configure the tmp directory.
+$config['system.file']['path']['temporary'] = "/mnt/files/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/tmp";
 
 // Include the Acquia database connection and other config.
 if (file_exists('/var/www/site-php')) {


### PR DESCRIPTION
Acquia suggested this for a particular client in a ticket, but we should do it by default for all sites on Acquia.