### PR TITLE
Multi site config, build and install

### DIFF
--- a/tasks/acquia.xml
+++ b/tasks/acquia.xml
@@ -88,7 +88,6 @@
             <property name="install_dir" value="${repo.dir}" />
             <property name="build.dir" value="${build.dir}" />
             <property name="drupal.root" value="${drupal.root}" />
-            <property name="drupal.sites_subdir" value="${drupal.sites_subdir}" />
         </phing>
     </target>
 

--- a/tasks/boilerplate.xml
+++ b/tasks/boilerplate.xml
@@ -12,6 +12,7 @@
       Include this file in your build.xml with:
         <import file="vendor/palantirnet/the-build/tasks/boilerplate.xml" />
       -->
+    <property name="build.sites" value="default" />
 
     <taskdef name="includeresource" classname="TheBuild\IncludeResourceTask" />
 
@@ -34,8 +35,8 @@
         <not><isset property="status.defaults_loaded" /></not>
         <then>
             <!-- Load properties for this environment, then for the default environment. -->
-            <property file="${build.dir}/conf/build.${build.env}.properties" />
-            <property file="${build.dir}/conf/build.default.properties" />
+            <property file="${build.dir}/conf/build.${build.env}.env.properties" />
+            <property file="${build.dir}/conf/build.default.env.properties" />
 
             <property name="status.defaults_loaded" value="true" />
         </then>
@@ -47,7 +48,7 @@
         -->
     <target name="status">
         <if>
-            <not><available file="${build.dir}/conf/build.default.properties" /></not>
+            <not><available file="${build.dir}/conf/build.default.env.properties" /></not>
             <then>
                 <echo>You should at least have a default properties file. Start with:
                 vendor/bin/phing configure -Dbuild.env=default</echo>
@@ -61,23 +62,28 @@
 
 
     <!-- Target: configure -->
-    <target name="configure" description="Interactive configuration for Drupal project settings.">
+    <target name="configure" description="Interactive configuration for project environment settings.">
         <phing phingfile="${phing.dir.boilerplate}/configure.xml" inheritAll="false" dir="${build.dir}">
             <property name="build.env" value="${build.env}" />
             <property name="build.dir" value="${build.dir}" />
+            <property name="properties.type" value="env" />
+            <property name="properties.name" value="${build.env}" />
 
-            <!-- Load properties from the environment we're editing, with the prefix "default.*" -->
-            <property file="${build.dir}/conf/build.${build.env}.properties" prefix="default" />
-            <property file="${build.dir}/conf/build.default.properties" prefix="default" />
+            <!-- Load properties for this environment, then for the default environment. -->
+            <property file="${build.dir}/conf/build.${build.env}.env.properties" />
+            <property file="${build.dir}/conf/build.default.env.properties" />
 
             <!-- Prompts and defaults -->
+            <property name="prompt.build.sites" value="Drupal multisite(s) to configure?" />
+            <property name="default.build.sites" value="default" />
+
             <property name="prompt.build.artifact_mode" value="Artifact mode (copy,symlink)" />
             <property name="default.build.artifact_mode" value="symlink" />
 
             <property name="prompt.build.test_output" value="Test output directory (use ${env.CIRCLE_TEST_REPORTS} for Circle)" />
             <property name="default.build.test_output" value="/dev/null" />
 
-            <property name="update" value="build.artifact_mode,build.test_output" />
+            <property name="update" value="build.sites,build.artifact_mode,build.test_output" />
         </phing>
     </target>
 

--- a/tasks/boilerplate.xml
+++ b/tasks/boilerplate.xml
@@ -91,8 +91,11 @@
 
             <!-- Defaults. -->
             <property name="default.build.drupal.root" value="web" />
+            <property name="default.build.drupal.settings" value="conf/drupal/settings.php" />
+            <property name="default.build.drupal.services" value="conf/drupal/services.yml" />
+
             <property name="update" value="build.sites,build.artifact_mode,build.test_output" />
-            <property name="dump" value="build.drupal.root" />
+            <property name="dump" value="build.drupal.root,build.drupal.settings,build.drupal.services" />
         </phing>
     </target>
 

--- a/tasks/boilerplate.xml
+++ b/tasks/boilerplate.xml
@@ -89,7 +89,10 @@
             <property name="prompt.build.test_output" value="Test output directory (use ${env.CIRCLE_TEST_REPORTS} for Circle)" />
             <property name="default.build.test_output" value="/dev/null" />
 
+            <!-- Defaults. -->
+            <property name="default.build.drupal.root" value="web" />
             <property name="update" value="build.sites,build.artifact_mode,build.test_output" />
+            <property name="dump" value="build.drupal.root" />
         </phing>
     </target>
 

--- a/tasks/boilerplate.xml
+++ b/tasks/boilerplate.xml
@@ -12,7 +12,6 @@
       Include this file in your build.xml with:
         <import file="vendor/palantirnet/the-build/tasks/boilerplate.xml" />
       -->
-    <property name="build.sites" value="default" />
 
     <taskdef name="includeresource" classname="TheBuild\IncludeResourceTask" />
 
@@ -61,8 +60,15 @@
     </target>
 
 
-    <!-- Target: configure -->
-    <target name="configure" description="Interactive configuration for project environment settings.">
+    <!-- Configure ALL the things. -->
+    <target name="configure" description="Interactive configuration for project settings.">
+        <phingcall target="configure-emv" />
+        <phing phingfile="${phing.dir.drupal}/drupal.xml" inheritAll="true" dir="${build.dir}" target="drupal-configure-sites" />
+    </target>
+
+
+    <!-- Do environment-specific configurations. -->
+    <target name="configure-emv" description="Interactive configuration for project environment settings.">
         <phing phingfile="${phing.dir.boilerplate}/configure.xml" inheritAll="false" dir="${build.dir}">
             <property name="build.env" value="${build.env}" />
             <property name="build.dir" value="${build.dir}" />

--- a/tasks/boilerplate.xml
+++ b/tasks/boilerplate.xml
@@ -74,7 +74,7 @@
             <property file="${build.dir}/conf/build.default.env.properties" />
 
             <!-- Prompts and defaults -->
-            <property name="prompt.build.sites" value="Drupal multisite(s) to configure?" />
+            <property name="prompt.build.sites" value="Drupal multisite(s) to configure separated by commas" />
             <property name="default.build.sites" value="default" />
 
             <property name="prompt.build.artifact_mode" value="Artifact mode (copy,symlink)" />

--- a/tasks/boilerplate.xml
+++ b/tasks/boilerplate.xml
@@ -33,9 +33,8 @@
     <if>
         <not><isset property="status.defaults_loaded" /></not>
         <then>
-            <!-- Load properties for this environment, then for the default environment. -->
+            <!-- Load properties for this environment, then for the sites. -->
             <property file="${build.dir}/conf/build.${build.env}.env.properties" />
-            <property file="${build.dir}/conf/build.default.env.properties" />
 
             <property name="status.defaults_loaded" value="true" />
         </then>
@@ -62,13 +61,13 @@
 
     <!-- Configure ALL the things. -->
     <target name="configure" description="Interactive configuration for project settings.">
-        <phingcall target="configure-emv" />
+        <phingcall target="configure-env" />
         <phing phingfile="${phing.dir.drupal}/drupal.xml" inheritAll="true" dir="${build.dir}" target="drupal-configure-sites" />
     </target>
 
 
     <!-- Do environment-specific configurations. -->
-    <target name="configure-emv" description="Interactive configuration for project environment settings.">
+    <target name="configure-env" description="Interactive configuration for project environment settings.">
         <phing phingfile="${phing.dir.boilerplate}/configure.xml" inheritAll="false" dir="${build.dir}">
             <property name="build.env" value="${build.env}" />
             <property name="build.dir" value="${build.dir}" />

--- a/tasks/configure.xml
+++ b/tasks/configure.xml
@@ -4,7 +4,7 @@
   @file configure.xml
   Interactive configuration for the-build.
 
-  Copyright 2016 Palantir.net, Inc.
+  Copyright 2016, 2017 Palantir.net, Inc.
   -->
 
 <project name="configure" default="configure">
@@ -18,38 +18,61 @@
 
 
     <!-- Target: configure -->
+    <target name="configure-sites" >
+
+        <if>
+            <not><isset property="build.sites"></isset></not>
+            <then>
+                <property name="build.sites" value="default" />
+            </then>
+        </if>
+
+        <!-- Configure each drupal site. -->
+        <foreach list="${build.sites}" target="drupal-configure" param="drupal.sites_subdir" />
+
+    </target>
+
+
+    <!-- Configure the build environment. -->
     <!--
-        Try:
-        configure -Dbuild.env=vagrant -Dupdate=drupal.site_name              ## Updates drupal.site_name only
-        configure -Dbuild.env=vagrant -Dupdate=drupal.root -Ddrupal.root=www ## Updates drupal.root to www
-        configure -Dbuild.env=vagrant -Dupdate=drupal.new_setting            ## Adds a new setting
-     -->
-    <target name="configure">
+    Try:
+    configure-env -Dbuild.env=vagrant -Dupdate=drupal.root -Ddrupal.root=www ## Updates drupal.root to www
+    configure-env -Dbuild.env=vagrant -Dupdate=env.new_setting               ## Adds a new setting
+    -->
+    <target name="configure-env">
         <fail unless="build.env" />
+
+        <!-- Initialize the environment. -->
+        <phingcall target="configure-init-environment" />
+
+        <phingcall target="configure" description="Configure ${build.env} environment." >
+            <property name="properties.type" value="env" />
+            <property name="properties.name" value="${build.env}" />
+        </phingcall>
+
+        <phingcall target="configure-sites" description="Configure Drupal sites." >
+            <property name="properties.type" value="site" />
+        </phingcall>
+
+    </target>
+
+
+    <!-- Add/update a configuration file. -->
+    <target name="configure">
+
+        <fail unless="properties.type" />
+        <fail unless="properties.name" />
 
         <property name="update" value="" />
         <property name="dump" value="" />
 
-        <!--
-            Defaults and prompts should come from the caller.
-
-            Interactive updates:
-                <property name="prompt.drupal.root" value="Drupal root" />
-                <property name="default.drupal.root" value="web" />
-                <property name="update" value="drupal.root,something.else" />
-
-            Silent defaults:
-                <property name="default.drupal.uri" value="http://${phing.project.name}.local" />
-                <property name="dump" value="drupal.uri,another.var" />
-            -->
-
-        <!-- Initialized the properties file -->
-        <property name="propertiesfile" value="conf/build.${build.env}.properties" />
+        <!-- Initialize the environment. -->
+        <property name="propertiesfile" value="conf/build.${properties.name}.${properties.type}.properties" />
         <phingcall target="configure-init-environment" />
 
-        <!-- Load properties from the environment we're editing, with the prefix "default.*" -->
+        <!-- Load properties from the file we're editing, with the prefix "default.*" -->
         <property file="${build.dir}/${propertiesfile}" prefix="default" />
-        <property file="${build.dir}/conf/build.default.properties" prefix="default" />
+        <property file="${build.dir}/conf/build.default.${properties.type}.properties" prefix="default" />
 
         <!-- Update properties interactively. -->
         <foreach list="${update}" target="configure-update-property" param="propertyname" />
@@ -61,7 +84,6 @@
 
     <target name="configure-init-environment">
         <fail unless="build.dir" />
-        <fail unless="propertiesfile" />
 
         <!-- Create the conf directory if it doesn't already exist. -->
         <if>
@@ -73,7 +95,10 @@
 
         <!-- Create the properties file if it doesn't already exist. -->
         <if>
-            <not><available file="${build.dir}/${propertiesfile}" /></not>
+            <and>
+                <isset property="propertiesfile" />
+                <not><available file="${build.dir}/${propertiesfile}" /></not>
+            </and>
             <then>
                 <touch file="${build.dir}/${propertiesfile}" />
             </then>
@@ -83,6 +108,7 @@
 
     <target name="configure-update-property-silent">
         <fail unless="propertyname" />
+        <fail unless="propertiesfile" />
         <fail unless="default.${propertyname}" />
 
         <property name="${propertyname}" value="${default.${propertyname}}" />

--- a/tasks/configure.xml
+++ b/tasks/configure.xml
@@ -72,7 +72,6 @@
 
         <!-- Load properties from the file we're editing, with the prefix "default.*" -->
         <property file="${build.dir}/${propertiesfile}" prefix="default" />
-        <property file="${build.dir}/conf/build.default.${properties.type}.properties" prefix="default" />
 
         <!-- Update properties interactively. -->
         <foreach list="${update}" target="configure-update-property" param="propertyname" />

--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -117,14 +117,13 @@
 
 
     <target name="drupal-build" description="Prepare Drupal for installation.">
-
         <fail unless="build.sites"/>
 
         <phingcall target="drupal-prepare-filesystem" />
-        <foreach list="$(build.sites)" target="prepare-site" param="drupal.site" />
-        <phingcall target="drupal-prepare-settings" />
-        <phingcall target="drupal-prepare-services" />
+        <foreach list="${build.sites}" target="prepare-site" param="drupal.site" />
+
     </target>
+
 
     <!-- Target: drupal-prepare-filesystem -->
     <target name="drupal-prepare-filesystem">
@@ -137,13 +136,34 @@
 
     </target>
 
-    <target name="prepare-site">
+
+    <!-- Prepare the Drupal site directory, config dir, settings, and services. -->
+    <target name="prepare-site" description="Prepare the Drupal site directory, config dir, settings, and services." >
+        <fail unless="build.env" />
+        <fail unless="build.dir" />
+        <fail unless="drupal.site" />
+
+        <!-- Load properties for this site. -->
+        <property file="${build.dir}/conf/build.${build.env}.env.properties" />
+        <property file="${build.dir}/conf/build.${drupal.site}.site.properties" />
+
+        <phingcall target="prepare-site-dir" />
+        <phingcall target="drupal-prepare-settings" />
+        <phingcall target="drupal-prepare-services" />
+
+    </target>
+
+
+    <!-- Prepare the site directory and set file permissions. -->
+    <target name="prepare-site-dir" description="Prepare the Drupal site directory and set file permissions.">
+        <fail unless="drupal.site" />
         <fail unless="build.dir" />
         <fail unless="build.drupal.root" />
-        <fail unless="drupal.site" />
-        <property file="${build.dir}/conf/build.${build.env}.env.properties" />
+        <echoproperties />
 
 
+
+        <mkdir dir="${build.dir}/conf/${drupal.config_sync_directory}" />
         <mkdir dir="${build.dir}/${build.drupal.root}/sites/${drupal.site}" />
         <mkdir dir="${build.dir}/${build.drupal.root}/${drupal.settings.file_public_path}" />
 

--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -42,9 +42,9 @@
     <property name="drupal.config_sync_directory" value="../conf/drupal/config" /> <!-- pantheon = private/config -->
     <property name="build.drupal.settings" value="conf/drupal/settings.php" />
     <property name="build.drupal.services" value="conf/drupal/services.yml" />
+    <property name="drupal.sites_subdir" value="default" /> <!-- Directory within 'sites' dir in the drupal root -->
 
     <!-- These properties will generally not change. -->
-    <property name="drupal.sites_subdir" value="default" /> <!-- Directory within 'sites' dir in the drupal root -->
     <property name="drupal.admin_user" value="admin" />
 
     <!-- Configuration properties for the 'drush' Phing task. -->

--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -22,6 +22,11 @@
     <fail unless="projectname" />
 
 
+    <!-- Load properties for the environment." -->
+    <property file="${build.dir}/conf/build.${build.env}.env.properties" />
+    <property file="${build.dir}/conf/build.default.env.properties" />
+
+
     <!-- These properties will generally be set in the default build properties file. -->
     <property name="drupal.root" value="web" />
     <property name="drupal.site_name" value="${projectname}" />
@@ -55,45 +60,52 @@
 
 
     <!-- Target: drupal-configure -->
-    <target name="drupal-configure" description="Configure the Drupal build.">
+    <target name="drupal-configure" description="Interactively configure a Drupal site for this build.">
+        <fail unless="drupal.sites_subdir" />
+
+
         <!-- Generate a hash salt -->
-        <php expression="hash('sha256', print_r($_SERVER, TRUE))" returnProperty="hash_salt" />
+        <php expression="hash('sha256', print_r($_SERVER . '${drupal.sites_subdir}', TRUE))" returnProperty="hash_salt" />
 
         <phing phingfile="${phing.dir.drupal}/configure.xml" inheritAll="false" dir="${build.dir}">
             <property name="build.env" value="${build.env}" />
             <property name="build.dir" value="${build.dir}" />
 
-            <!-- Load properties from the environment we're editing, with the prefix "default.*" -->
-            <property file="${build.dir}/conf/build.${build.env}.properties" prefix="default" />
-            <property file="${build.dir}/conf/build.default.properties" prefix="default" />
+            <property name="properties.type" value="site" />
+            <property name="properties.name" value="${drupal.sites_subdir}" />
 
-            <!-- Prompts and defaults -->
-            <property name="prompt.drupal.site_name" value="Human-readable site name" />
+            <!--<property name="drupal.sites_subdir" value="${drupal.sites_subdir}" />-->
+
+            <!-- Load properties for the site we're editing, with the prefix "default.*" -->
+            <property file="${build.dir}/conf/build.${drupal.sites_subdir}.site.properties" prefix="default" />
+            <property file="${build.dir}/conf/build.default.site.properties" prefix="default" />
+
+            <property name="prompt.drupal.site_name" value="${drupal.sites_subdir}: Human-readable site name" />
             <property name="default.drupal.site_name" value="${projectname}" />
 
-            <property name="prompt.drupal.profile" value="Drupal install profile" />
+            <property name="prompt.drupal.profile" value="${drupal.sites_subdir}: Drupal install profile" />
             <property name="default.drupal.profile" value="standard" />
 
-            <property name="prompt.drupal.modules_enable" value="Comma-separated list of modules to enable after install" />
+            <property name="prompt.drupal.modules_enable" value="${drupal.sites_subdir}: Comma-separated list of modules to enable after install" />
             <property name="default.drupal.modules_enable" value="" />
 
-            <property name="prompt.drupal.database.database" value="Drupal database name" />
-            <property name="default.drupal.database.database" value="drupal" />
+            <property name="prompt.drupal.database.database" value="${drupal.sites_subdir}: Drupal database name" />
+            <property name="default.drupal.database.database" value="${drupal.sites_subdir}" />
 
-            <property name="prompt.drupal.database.username" value="Drupal database username" />
-            <property name="default.drupal.database.username" value="root" />
+            <property name="prompt.drupal.database.username" value="${drupal.sites_subdir}: Drupal database username" />
+            <property name="default.drupal.database.username" value="${drupal.sites_subdir}" />
 
-            <property name="prompt.drupal.database.password" value="Drupal database password" />
-            <property name="default.drupal.database.password" value="root" />
+            <property name="prompt.drupal.database.password" value="${drupal.sites_subdir}: Drupal database password" />
+            <property name="default.drupal.database.password" value="${drupal.sites_subdir}" />
 
             <property name="prompt.drupal.database.host" value="Drupal database host" />
             <property name="default.drupal.database.host" value="127.0.0.1" />
 
             <!-- Just defaults -->
-            <property name="default.drupal.settings.file_public_path" value="sites/default/files" />
+            <property name="default.drupal.settings.file_public_path" value="sites/${drupal.sites_subdir}/files" />
             <property name="default.drupal.settings.file_private_path" value="" />
             <property name="default.drupal.twig.debug" value="false" />
-            <property name="default.drupal.uri" value="http://${projectname}.local" />
+            <property name="default.drupal.uri" value="http://${drupal.sites_subdir}.${projectname}.local" />
             <property name="default.drupal.root" value="web" />
 
             <!-- Generated hash salt -->
@@ -104,6 +116,11 @@
         </phing>
     </target>
 
+    <!-- Configure the Drupal sites. -->
+    <target name="drupal-configure-sites" description="Configure the Drupal sites.">
+        <fail unless="build.sites" />
+        <foreach list="${build.sites}" target="drupal-configure" param="drupal.sites_subdir" />
+    </target>
 
     <!-- Target: drush-prepare-drushrc -->
     <target name="drush-prepare-drushrc" description="Create a drushrc file for Vagrant.">
@@ -117,7 +134,11 @@
 
 
     <target name="drupal-build" description="Prepare Drupal for installation.">
+
+        <fail unless="build.sites"/>
+
         <phingcall target="drupal-prepare-filesystem" />
+        <foreach list="$(build.sites)" target="prepare-site" param="build.sitename" />
         <phingcall target="drupal-prepare-settings" />
         <phingcall target="drupal-prepare-services" />
     </target>

--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -221,7 +221,20 @@
 
 
     <!-- Target: drupal-install -->
-    <target name="drupal-install" description="Install Drupal.">
+    <target name="drupal-install" description="Install all the Drupals.">
+        <fail unless="build.env" />
+        <fail unless="build.sites" />
+        <foreach list="${build.sites}" target="drupal-install-site" param="drupal.site" />
+    </target>
+
+    <target name="drupal-install-site" description="Install a Drupal site.">
+        <!-- Ask which site to install if one wasn't specified. -->
+        <propertyprompt propertyName="drupal.site" promptText="Which Drupal site should we install? (${build.sites})" defaultValue="default" useExistingValue="true" />
+        <fail unless="drupal.site" />
+
+        <!-- Load the properties for the site. -->
+        <property file="${build.dir}/conf/build.${drupal.site}.site.properties" />
+
         <fail unless="drupal.settings.file_public_path" />
         <fail unless="build.drupal.root" />
         <fail unless="drupal.site_name" />

--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -22,104 +22,87 @@
     <fail unless="projectname" />
 
 
-    <!-- Load properties for the environment." -->
+    <!-- Load properties for the environment. -->
     <property file="${build.dir}/conf/build.${build.env}.env.properties" />
     <property file="${build.dir}/conf/build.default.env.properties" />
 
 
     <!-- These properties will generally be set in the default build properties file. -->
-    <property name="drupal.root" value="web" />
     <property name="drupal.site_name" value="${projectname}" />
     <property name="drupal.profile" value="standard" />
     <property name="drupal.hash_salt" value="temporary" />
-
-    <property name="drupal.settings.file_public_path" value="sites/default/files" />
-    <property name="drupal.settings.file_private_path" value="" />
-
-    <!-- These properties will probably change per-environment. -->
-    <property name="drupal.uri" value="http://${projectname}.local" />
-    <property name="drupal.database.database" value="default" />
-    <property name="drupal.database.username" value="drupal" />
-    <property name="drupal.database.password" value="drupal" />
-    <property name="drupal.database.host" value="127.0.0.1" />
-    <property name="drupal.modules_enable" value="" />
-    <property name="drupal.twig.debug" value="false" />
-    <property name="drupal.config_sync_directory" value="../conf/drupal/config" /> <!-- pantheon = private/config -->
-    <property name="build.drupal.settings" value="conf/drupal/settings.php" />
-    <property name="build.drupal.services" value="conf/drupal/services.yml" />
-    <property name="drupal.sites_subdir" value="default" /> <!-- Directory within 'sites' dir in the drupal root -->
 
     <!-- These properties will generally not change. -->
     <property name="drupal.admin_user" value="admin" />
 
     <!-- Configuration properties for the 'drush' Phing task. -->
     <property name="drush.bin" value="${build.dir}/vendor/bin/drush" />
+    <!-- @todo One URI won't work with multisite. Try Drupal VM's aliases? -->
+    <property name="drupal.uri" value="http://${projectname}.local" />
     <property name="drush.uri" refid="drupal.uri" />
-    <property name="drush.root" value="${build.dir}/${drupal.root}" />
+    <property name="drush.root" value="${build.dir}/${build.drupal.root}" />
     <property name="drush.config" value="${build.dir}/conf/drushrc.php" />
 
 
     <!-- Target: drupal-configure -->
     <target name="drupal-configure" description="Interactively configure a Drupal site for this build.">
-        <fail unless="drupal.sites_subdir" />
+        <fail unless="drupal.site" />
 
 
         <!-- Generate a hash salt -->
-        <php expression="hash('sha256', print_r($_SERVER . '${drupal.sites_subdir}', TRUE))" returnProperty="hash_salt" />
+        <php expression="hash('sha256', print_r($_SERVER . '${drupal.site}', TRUE))" returnProperty="hash_salt" />
 
         <phing phingfile="${phing.dir.drupal}/configure.xml" inheritAll="false" dir="${build.dir}">
             <property name="build.env" value="${build.env}" />
             <property name="build.dir" value="${build.dir}" />
 
             <property name="properties.type" value="site" />
-            <property name="properties.name" value="${drupal.sites_subdir}" />
-
-            <!--<property name="drupal.sites_subdir" value="${drupal.sites_subdir}" />-->
+            <property name="properties.name" value="${drupal.site}" />
 
             <!-- Load properties for the site we're editing, with the prefix "default.*" -->
-            <property file="${build.dir}/conf/build.${drupal.sites_subdir}.site.properties" prefix="default" />
+            <property file="${build.dir}/conf/build.${drupal.site}.site.properties" prefix="default" />
             <property file="${build.dir}/conf/build.default.site.properties" prefix="default" />
 
-            <property name="prompt.drupal.site_name" value="${drupal.sites_subdir}: Human-readable site name" />
+            <property name="prompt.drupal.site_name" value="${drupal.site}: Human-readable site name" />
             <property name="default.drupal.site_name" value="${projectname}" />
 
-            <property name="prompt.drupal.profile" value="${drupal.sites_subdir}: Drupal install profile" />
+            <property name="prompt.drupal.profile" value="${drupal.site}: Drupal install profile" />
             <property name="default.drupal.profile" value="standard" />
 
-            <property name="prompt.drupal.modules_enable" value="${drupal.sites_subdir}: Comma-separated list of modules to enable after install" />
+            <property name="prompt.drupal.modules_enable" value="${drupal.site}: Comma-separated list of modules to enable after install" />
             <property name="default.drupal.modules_enable" value="" />
 
-            <property name="prompt.drupal.database.database" value="${drupal.sites_subdir}: Drupal database name" />
-            <property name="default.drupal.database.database" value="${drupal.sites_subdir}" />
+            <property name="prompt.drupal.database.database" value="${drupal.site}: Drupal database name" />
+            <property name="default.drupal.database.database" value="${drupal.site}" />
 
-            <property name="prompt.drupal.database.username" value="${drupal.sites_subdir}: Drupal database username" />
-            <property name="default.drupal.database.username" value="${drupal.sites_subdir}" />
+            <property name="prompt.drupal.database.username" value="${drupal.site}: Drupal database username" />
+            <property name="default.drupal.database.username" value="${drupal.site}" />
 
-            <property name="prompt.drupal.database.password" value="${drupal.sites_subdir}: Drupal database password" />
-            <property name="default.drupal.database.password" value="${drupal.sites_subdir}" />
+            <property name="prompt.drupal.database.password" value="${drupal.site}: Drupal database password" />
+            <property name="default.drupal.database.password" value="${drupal.site}" />
 
             <property name="prompt.drupal.database.host" value="Drupal database host" />
             <property name="default.drupal.database.host" value="127.0.0.1" />
 
             <!-- Just defaults -->
-            <property name="default.drupal.settings.file_public_path" value="sites/${drupal.sites_subdir}/files" />
+            <property name="default.drupal.config_sync_directory" value="../conf/drupal/${drupal.site}/config" />
+            <property name="default.drupal.settings.file_public_path" value="sites/${drupal.site}/files" />
             <property name="default.drupal.settings.file_private_path" value="" />
             <property name="default.drupal.twig.debug" value="false" />
-            <property name="default.drupal.uri" value="http://${drupal.sites_subdir}.${projectname}.local" />
-            <property name="default.drupal.root" value="web" />
+            <property name="default.drupal.uri" value="http://${drupal.site}.${projectname}.local" />
 
             <!-- Generated hash salt -->
             <property name="default.drupal.hash_salt" value="${hash_salt}" />
 
             <property name="update" value="drupal.site_name,drupal.profile,drupal.modules_enable,drupal.database.database,drupal.database.username,drupal.database.password,drupal.database.host" />
-            <property name="dump" value="drupal.settings.file_public_path,drupal.settings.file_private_path,drupal.twig.debug,drupal.uri,drupal.hash_salt,drupal.root" />
+            <property name="dump" value="drupal.config_sync_directory,drupal.settings.file_public_path,drupal.settings.file_private_path,drupal.twig.debug,drupal.uri,drupal.hash_salt" />
         </phing>
     </target>
 
     <!-- Configure the Drupal sites. -->
     <target name="drupal-configure-sites" description="Configure the Drupal sites.">
         <fail unless="build.sites" />
-        <foreach list="${build.sites}" target="drupal-configure" param="drupal.sites_subdir" />
+        <foreach list="${build.sites}" target="drupal-configure" param="drupal.site" />
     </target>
 
     <!-- Target: drush-prepare-drushrc -->
@@ -138,37 +121,46 @@
         <fail unless="build.sites"/>
 
         <phingcall target="drupal-prepare-filesystem" />
-        <foreach list="$(build.sites)" target="prepare-site" param="build.sitename" />
+        <foreach list="$(build.sites)" target="prepare-site" param="drupal.site" />
         <phingcall target="drupal-prepare-settings" />
         <phingcall target="drupal-prepare-services" />
     </target>
 
     <!-- Target: drupal-prepare-filesystem -->
     <target name="drupal-prepare-filesystem">
-        <fail unless="drupal.root" />
-        <fail unless="drupal.sites_subdir" />
+        <fail unless="build.drupal.root" />
 
-        <!-- Create the Drupal modules, themes, profiles, and sites directories. -->
+        <!-- Create the Drupal modules, themes, and profiles directories. -->
         <foreach target="create-placeholder" param="placeholder_for">
-            <filelist dir="${build.dir}" files="${drupal.root}/modules/custom,${drupal.root}/themes/custom,${drupal.root}/profiles/custom,${drupal.root}/sites/${drupal.sites_subdir}" />
+            <filelist dir="${build.dir}" files="${build.drupal.root}/modules/custom,${build.drupal.root}/themes/custom,${build.drupal.root}/profiles/custom" />
         </foreach>
 
+    </target>
+
+    <target name="prepare-site">
+        <fail unless="build.dir" />
+        <fail unless="build.drupal.root" />
+        <fail unless="drupal.site" />
+        <property file="${build.dir}/conf/build.${build.env}.env.properties" />
+
+
+        <mkdir dir="${build.dir}/${build.drupal.root}/sites/${drupal.site}" />
+        <mkdir dir="${build.dir}/${build.drupal.root}/${drupal.settings.file_public_path}" />
+
         <!-- The site directory needs to have some perms. -->
-        <chmod file="${drupal.root}/sites/${drupal.sites_subdir}" mode="750" />
+        <chmod file="${build.drupal.root}/sites/${drupal.site}" mode="750" />
 
         <!-- The public files directory, and everything in it, needs to be world writable. -->
-        <resolvepath propertyName="drupal.settings.file_public_path.resolved" file="${drupal.root}/${drupal.settings.file_public_path}" />
+        <resolvepath propertyName="drupal.settings.file_public_path.resolved" file="${build.drupal.root}/${drupal.settings.file_public_path}" />
         <exec command="chmod -R 777 ${drupal.settings.file_public_path.resolved}" />
     </target>
 
-
     <!-- Target: drupal-prepare-settings -->
     <target name="drupal-prepare-settings">
-        <fail unless="drupal.root" />
-        <fail unless="drupal.sites_subdir" />
+        <fail unless="drupal.site" />
         <fail unless="build.drupal.settings" />
 
-        <copy file="${build.dir}/${build.drupal.settings}" tofile="${build.dir}/${drupal.root}/sites/${drupal.sites_subdir}/settings.php" overwrite="true" mode="555">
+        <copy file="${build.dir}/${build.drupal.settings}" tofile="${build.dir}/${build.drupal.root}/sites/${drupal.site}/settings.php" overwrite="true" mode="555">
             <filterchain>
                 <expandproperties />
             </filterchain>
@@ -178,11 +170,11 @@
 
     <!-- Target: drupal-prepare-services -->
     <target name="drupal-prepare-services">
-        <fail unless="drupal.root" />
-        <fail unless="drupal.sites_subdir" />
+        <fail unless="build.drupal.root" />
+        <fail unless="drupal.site" />
         <fail unless="build.drupal.services" />
 
-        <copy file="${build.dir}/${build.drupal.services}" tofile="${build.dir}/${drupal.root}/sites/${drupal.sites_subdir}/services.yml" overwrite="true" mode="644">
+        <copy file="${build.dir}/${build.drupal.services}" tofile="${build.dir}/${build.drupal.root}/sites/${drupal.site}/services.yml" overwrite="true" mode="644">
             <filterchain>
                 <expandproperties />
             </filterchain>
@@ -211,22 +203,22 @@
     <!-- Target: drupal-install -->
     <target name="drupal-install" description="Install Drupal.">
         <fail unless="drupal.settings.file_public_path" />
-        <fail unless="drupal.root" />
+        <fail unless="build.drupal.root" />
         <fail unless="drupal.site_name" />
-        <fail unless="drupal.sites_subdir" />
+        <fail unless="drupal.site" />
         <fail unless="drupal.profile" />
         <fail unless="drupal.modules_enable" />
 
         <phingcall target="validate-clean-conf" />
 
-        <resolvepath propertyName="drupal.settings.file_public_path.resolved" file="${drupal.root}/${drupal.settings.file_public_path}" />
+        <resolvepath propertyName="drupal.settings.file_public_path.resolved" file="${build.drupal.root}/${drupal.settings.file_public_path}" />
 
         <!-- The sites subdirectory should be writable; Drupal will change the
              permissions on this directory after install. -->
-        <chmod file="${build.dir}/${drupal.root}/sites/${drupal.sites_subdir}" mode="777" />
+        <chmod file="${build.dir}/${build.drupal.root}/sites/${drupal.site}" mode="777" />
 
         <!-- Make settings.php writable -->
-        <chmod file="${build.dir}/${drupal.root}/sites/${drupal.sites_subdir}/settings.php" mode="777" />
+        <chmod file="${build.dir}/${build.drupal.root}/sites/${drupal.site}/settings.php" mode="777" />
 
         <!-- Delete and re-create the public files directory -->
         <delete file="${drupal.settings.file_public_path.resolved}" />
@@ -241,7 +233,7 @@
                 </not>
             </and>
             <then>
-                <resolvepath propertyName="drupal.settings.file_private_path.resolved" file="${drupal.root}/${drupal.settings.file_private_path}" />
+                <resolvepath propertyName="drupal.settings.file_private_path.resolved" file="${build.drupal.root}/${drupal.settings.file_private_path}" />
                 <delete file="${drupal.settings.file_private_path.resolved}" />
                 <delete dir="${drupal.settings.file_private_path.resolved}" />
                 <mkdir dir="${drupal.settings.file_private_path.resolved}" mode="777" />

--- a/tasks/lib/artifacts.xml
+++ b/tasks/lib/artifacts.xml
@@ -25,7 +25,6 @@
         <fail unless="install_dir" />
         <fail unless="build.dir" />
         <fail unless="drupal.root" />
-        <fail unless="drupal.sites_subdir" />
 
         <!-- Relative path to the Drupal root within the install dir -->
         <property name="drupal.root_name" value="docroot/" />
@@ -64,11 +63,7 @@
             doing it based on what is checked in to git prevents us from
             accidentally adding local files or settings.php in to the
             build repository.
-
-            AND, drupal has applied permissions to the sites directory that
-            prevent us from writing to it, so we need to squash them.
             -->
-        <exec command="chmod 777 web/sites/${drupal.sites_subdir}" dir="${build.dir}" />
         <tempfile property="tmpfile" destdir="${build.dir}/artifacts" />
         <exec command="git ls-files" dir="${build.dir}/web" output="${tmpfile}" />
         <copy todir="${drupal.root}" overwrite="true" haltonerror="true">


### PR DESCRIPTION
## Description:

Adds multisite configuration, build and install tools to the-build:

Still needs some work for deploy artifacts and drush.

The drushrc.php method assumes a single URI, so it is impossible to install multiple sites with the-build because no matter how well you've configured, it always uses the default uri. Need to decide how to proceed there.

Deployment makes some similar assumptions. I *think* I've resolved the bulk of it, but it still needs a bit more work and a lot of poking to see what breaks.

### `vendor/bin/phing configure` 
Behaves as before. It creates .properties files which will be used by the build script below. Configuration for environment is separated from that of the site itself. This allows us to use any number of combinations of environments and sites without files for every permutation of the two. So for example, on most projects we would have:
* `build.vagrant.env.properties` for environment specific settings like the list of sites to build for this environment (build.sites), artifact mode (build.artifact_mode), and the drupal root (build.drupal.root). In cases where there will not be a multisite environment, we still use this configuration, but there is only one site, "default" in the build.sites list.
* `build.default.site.properties` for the settings should be used in sites/default/settings.php.

### `vendor/bin/phing drupal-build`
Builds all sites configured for this environment by looping thru build.sites and calling prepare-site on each one. Assuming configuration is built with this version, this is safe to use as before even if there is only one site. One is a subset of many.


### `vendor/bin/phing drupal-install-site`
Installs an individual site for a given environment. You can pass the name of the site to build like `vendor/bin/phing drupal-install-site -Ddrupal-site=default` otherwise it will ask which site to install.

### `vendor/bin/phing drupal-install`
Locally installs all the Drupals configured for the chosen environment by looping thru build.sites and calling `drupal-install-site` on each one. This is also safe to use as before even when there is only one site configured. One is a subset of many.

## To Test:
- [ ] Check out [the companion PR for the AMA d8 environment](https://github.com/AmericanMedicalAssociation/ama-d8/pull/4) and bring up the VM.
- [ ] Run `vendor/bin/phing build install` and validate two sites are installed.
- [ ] Run the behat tests and note they are being run against both environments.
- [ ] Configure a new project using the drupal-skeleton and this branch. Use the `vendor/bin/phing configure` command and validate it writes the configuration files as expected based on the instructions above.



## Automated Tests:

* https://github.com/AmericanMedicalAssociation/ama-d8/blob/EWL-3131_Multisite/features/test.ama-d8.local/installation.feature
* https://github.com/AmericanMedicalAssociation/ama-d8/blob/EWL-3131_Multisite/features/www.ama-d8.local/installation.feature
---

[Pull Request Guidelines](https://github.com/palantirnet/development_documentation/blob/master/guidelines/pr_review.md)
