### PR TITLE
Update circle.yml for new butler config

### DIFF
--- a/circle.dist.yml
+++ b/circle.dist.yml
@@ -29,7 +29,7 @@ dependencies:
     - composer install --no-interaction
 
   cache_directories:
-    - node_modules
+    - styleguide/node_modules
     - vendor
     - web/core
     - web/modules/contrib
@@ -39,6 +39,7 @@ dependencies:
 
 test:
   pre:
+    - npm --prefix styleguide/ install styleguide/
     - vendor/bin/phing build install migrate
 
   override:


### PR DESCRIPTION
When running circle using the Spress setup for Butler there are errors in testing because it's looking for the `node_modules` in other places. This should fix the break on install, however there might be additional issues that I'm still currently unaware of.