### PR TITLE
Add squizlabs/php_codesniffer as a dependency, since drupal/coder no …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,11 @@
     "require": {
         "continuousphp/phing-drush-task": "dev-master",
         "drupal/coder": "*",
+        "nilportugues/php_todo": "^1.0",
         "pear/versioncontrol_git": "@dev",
         "phing/phing": "^2.14",
-        "phpmd/phpmd" : "^2.4",
-        "nilportugues/php_todo": "^1.0"
+        "phpmd/phpmd": "^2.4",
+        "squizlabs/php_codesniffer": "2.8.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
…longer explicitly declares this dependency.