### PR TITLE
Add styleguide build command.

### DIFF
--- a/build.dist.xml
+++ b/build.dist.xml
@@ -14,8 +14,11 @@
 
     <!-- Default target: build -->
     <target name="build" description="Build the application.">
-        <phingcall target="drupal-build" />
         <phingcall target="styleguide" />
+        <phingcall target="drupal-build" />
+        <!-- Include styleguide resources in the theme. This approach will symlink
+             resources in development environments, and copy them for artifact builds. -->
+        <!-- <includeresource mode="${build.artifact_mode}" source="styleguide/source/assets/css" dest="${drupal.root}/themes/custom/example_theme/css" /> -->
     </target>
 
 

--- a/build.dist.xml
+++ b/build.dist.xml
@@ -9,6 +9,7 @@
     <!-- Make these commands available by default. -->
     <import file="vendor/palantirnet/the-build/tasks/drupal.xml" />
     <import file="vendor/palantirnet/the-build/tasks/acquia.xml" />
+    <import file="vendor/palantirnet/the-build/tasks/styleguide.xml" />
 
 
     <!-- Default target: build -->

--- a/build.dist.xml
+++ b/build.dist.xml
@@ -15,6 +15,7 @@
     <!-- Default target: build -->
     <target name="build" description="Build the application.">
         <phingcall target="drupal-build" />
+        <phingcall target="styleguide" />
     </target>
 
 

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -62,6 +62,15 @@ Cool! This phing-ism is what powers our environment-specific property layering a
 
 [More info](../tasks/drupal.xml#L16-L38)
 
+### Style Guide
+
+| Property | Default value | What is it? |
+|---|---|---|
+| `styleguide.root` | `styleguide` | Location of the style guide, relative to the project root. |
+| `styleguide.command` | `yarn default` | Command to compile the style guide assets, for use during the build and artifact steps. |
+
+[More info](../tasks/styleguide.xml#L22-L24)
+
 ### Code Review
 
 | Property | Default value | What is it? |

--- a/tasks/install.xml
+++ b/tasks/install.xml
@@ -61,6 +61,7 @@
         <echo message="Configure the default environment..." />
         <phing target="configure" phingfile="${phing.dir.install}/boilerplate.xml" />
         <phing target="drupal-configure" phingfile="${phing.dir.install}/drupal.xml" />
+        <phing target="styleguide-configure" phingfile="${phing.dir.install}/styleguide.xml" />
         <phing target="drush-prepare-drushrc" phingfile="${phing.dir.install}/drupal.xml" />
 
         <echo message="To configure properties for more environments, run: vendor/bin/phing configure -Dbuild.env=your_environment" />

--- a/tasks/styleguide.xml
+++ b/tasks/styleguide.xml
@@ -85,18 +85,6 @@
                 <exec dir="${styleguide.root.resolved}" command="yarn install --non-interactive --no-progress --prefer-offline" passthru="true" checkreturn="true" />
             </then>
         </if>
-
-        <!-- Run npm install in the styleguide, if there's no yarn.lock file. -->
-        <!-- @todo is there a decent way to check whether npm install has run? -->
-        <if>
-            <and>
-                <available file="${styleguide.root.resolved}/package.json" type="file" />
-                <not><available file="${styleguide.root.resolved}/yarn.lock" type="file" /></not>
-            </and>
-            <then>
-                <exec dir="${styleguide.root.resolved}" command="npm install" passthru="true" checkreturn="true" />
-            </then>
-        </if>
     </target>
 
 

--- a/tasks/styleguide.xml
+++ b/tasks/styleguide.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+
+<!--
+  @file styleguide.xml
+  Targets for managing the styleguide.
+
+  Copyright 2018 Palantir.net, Inc.
+  -->
+
+<project name="Styleguide" default="styleguide">
+    <!--
+      Include this file in your build.xml with:
+        <import file="vendor/palantirnet/the-build/tasks/styleguide.xml" />
+      -->
+
+
+    <fail unless="build.dir" />
+    <fail unless="build.env" />
+    <fail unless="projectname" />
+
+
+    <!-- These properties will generally be set in the default build properties file. -->
+    <property name="styleguide.root" value="styleguide" />
+    <property name="styleguide.command" value="yarn default" />
+
+    <!-- This is resolved at runtime. -->
+    <resolvepath propertyName="styleguide.root.resolved" file="${styleguide.root}" dir="${build.dir}" />
+
+
+    <!-- Target: styleguide-configure -->
+    <target name="styleguide-configure" description="Configure the styleguide build.">
+        <phing phingfile="${phing.dir.styleguide}/configure.xml" inheritAll="false" dir="${build.dir}">
+            <property name="build.env" value="${build.env}" />
+            <property name="build.dir" value="${build.dir}" />
+
+            <!-- Load properties from the environment we're editing, with the prefix "default.*" -->
+            <property file="${build.dir}/conf/build.${build.env}.properties" prefix="default" />
+            <property file="${build.dir}/conf/build.default.properties" prefix="default" />
+
+            <!-- Prompts and defaults -->
+            <property name="prompt.styleguide.root" value="Style guide directory, relative to the project root" />
+            <property name="default.styleguide.root" value="${styleguide.root}" />
+
+            <property name="prompt.styleguide.command" value="Style guide build command" />
+            <property name="default.styleguide.command" value="${styleguide.command}" />
+
+            <property name="update" value="styleguide.root,styleguide.command" />
+            <property name="dump" value="" />
+        </phing>
+    </target>
+
+
+    <!-- Target: styleguide -->
+    <target name="styleguide" description="Install and build the style guide.">
+
+        <phingcall target="styleguide-install" />
+
+        <!-- Run the styleguide build command. -->
+        <echo>Running build command in ${styleguide.root}: ${styleguide.command}</echo>
+        <exec dir="${styleguide.root.resolved}" command="${styleguide.command}" passthru="true" checkreturn="true" />
+    </target>
+
+
+    <!-- Target: styleguide-install -->
+    <target name="styleguide-install" description="Install the style guide.">
+
+        <!-- Run composer install in the styleguide. -->
+        <if>
+            <and>
+                <available file="${styleguide.root.resolved}/composer.lock" type="file" />
+                <not><available file="${styleguide.root.resolved}/vendor/autoload.php" type="file" /></not>
+            </and>
+            <then>
+                <exec dir="${styleguide.root.resolved}" command="composer install --no-interaction" passthru="true" checkreturn="true" />
+            </then>
+        </if>
+
+        <!-- Run yarn install in the styleguide. -->
+        <if>
+            <and>
+                <available file="${styleguide.root.resolved}/yarn.lock" type="file" />
+                <not><available file="${styleguide.root.resolved}/node_modules/.yarn-integrity" type="file" /></not>
+            </and>
+            <then>
+                <exec dir="${styleguide.root.resolved}" command="yarn install" passthru="true" checkreturn="true" />
+            </then>
+        </if>
+
+        <!-- Run npm install in the styleguide, if there's no yarn.lock file. -->
+        <if>
+            <and>
+                <available file="${styleguide.root.resolved}/package.json" type="file" />
+                <not><available file="${styleguide.root.resolved}/yarn.lock" type="file" /></not>
+            </and>
+            <then>
+                <exec dir="${styleguide.root.resolved}" command="npm install" passthru="true" checkreturn="true" />
+            </then>
+        </if>
+    </target>
+
+
+</project>

--- a/tasks/styleguide.xml
+++ b/tasks/styleguide.xml
@@ -79,7 +79,10 @@
         <if>
             <and>
                 <available file="${styleguide.root.resolved}/yarn.lock" type="file" />
-                <not><available file="${styleguide.root.resolved}/node_modules/.yarn-integrity" type="file" /></not>
+                <or>
+                  <not><available file="${styleguide.root.resolved}/node_modules/.yarn-integrity" type="file" /></not>
+                  <not><available file="${styleguide.root.resolved}/node_modules/node-sass/vendor/linux-x64-59/binding.node" type="file" /></not>
+                </or>
             </and>
             <then>
                 <exec dir="${styleguide.root.resolved}" command="yarn install --non-interactive --no-progress --prefer-offline" passthru="true" checkreturn="true" />

--- a/tasks/styleguide.xml
+++ b/tasks/styleguide.xml
@@ -87,6 +87,7 @@
         </if>
 
         <!-- Run npm install in the styleguide, if there's no yarn.lock file. -->
+        <!-- @todo is there a decent way to check whether npm install has run? -->
         <if>
             <and>
                 <available file="${styleguide.root.resolved}/package.json" type="file" />

--- a/tasks/styleguide.xml
+++ b/tasks/styleguide.xml
@@ -82,7 +82,7 @@
                 <not><available file="${styleguide.root.resolved}/node_modules/.yarn-integrity" type="file" /></not>
             </and>
             <then>
-                <exec dir="${styleguide.root.resolved}" command="yarn install" passthru="true" checkreturn="true" />
+                <exec dir="${styleguide.root.resolved}" command="yarn install --non-interactive --no-progress --prefer-offline" passthru="true" checkreturn="true" />
             </then>
         </if>
 


### PR DESCRIPTION
Completes [ZRAD-119](https://palantir.atlassian.net/browse/ZRAD-119) - Add styleguide target to palantirnet/the-build.

### To test:

1. Require this branch of the-build in a project: `composer require --dev palantirnet/the-build:dev-styleguide-build-commands`
2. Reinstall the-build: `vendor/bin/the-build-installer`
3. When prompted, make sure that the styleguide directory and styleguide command are correct for your styleguide (if you miss the prompts, just re-run the installer)
4. Run the build command: `phing build` -- this should install the styleguide dependencies and run the styleguide command that you configured
5. Run the styleguide command directly: `phing styleguide` -- since your dependencies are already installed, this should just rerun the styleguide command

### Open questions:

* Will this cover most of our styleguide use cases? Folks working on the styleguide will continue to use the yarn/npm gulp-based tooling for development. The intent of this command is to generate the assets required for an artifact build.
* This only supports composer and yarn right now -- and will only run install commands if those lockfiles are present. Do we need to also support npm?
  * Are we back to using npm only in some styleguides?
* Where should we document that this can be configured on existing projects by:
  1. Adding the new `<import>` line for the styleguide targets to the project's `build.xml`
  2. Adding the phing call to `styleguide` to the existing `build` target, if desired
  3. Configuring the styleguide variables with `phing styleguide-configure -Dbuild.env=default`