### PR TITLE
Allow specifying a node version on CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,14 +25,14 @@ jobs:
       - run:
           name: Install packages
           command: sudo apt-get install -y libpng-dev mysql-client
-      #- run:
-      #    name: Install nvm
-      #    command: |
-      #      set +e
-      #      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-      #      touch $BASH_ENV
-      #      echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
-      #      echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+      - run:
+          name: Install nvm
+          command: |
+            set +e
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+            touch $BASH_ENV
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
           name: Install PHP extensions
           command: sudo docker-php-ext-install pdo_mysql gd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,6 @@ jobs:
       #      touch $BASH_ENV
       #      echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
       #      echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-      #- run:
-      #    name: Install Node
-      #    command: |
-      #      nvm install "${NODE_VERSION}"
-      #      nvm alias default "${NODE_VERSION}"
       - run:
           name: Install PHP extensions
           command: sudo docker-php-ext-install pdo_mysql gd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
     environment:
       - PALANTIR_ENVIRONMENT: circle
       - DRUPAL_ROOT: web
+      - NODE_VERSION: 8
 
     branches:
       ignore:
@@ -24,6 +25,19 @@ jobs:
       - run:
           name: Install packages
           command: sudo apt-get install -y libpng-dev mysql-client
+      #- run:
+      #    name: Install nvm
+      #    command: |
+      #      set +e
+      #      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+      #      touch $BASH_ENV
+      #      echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+      #      echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+      #- run:
+      #    name: Install Node
+      #    command: |
+      #      nvm install "${NODE_VERSION}"
+      #      nvm alias default "${NODE_VERSION}"
       - run:
           name: Install PHP extensions
           command: sudo docker-php-ext-install pdo_mysql gd


### PR DESCRIPTION
Open questions:

* Should we cache the `~/.nvm` directory?
* Should this be uncommented by default?