### PR TITLE
Disable render cache for development

### DIFF
--- a/defaults/templates/drupal.settings.build.php
+++ b/defaults/templates/drupal.settings.build.php
@@ -18,10 +18,17 @@ $config_directories = array();
 $config_directories[CONFIG_SYNC_DIRECTORY] = '${drupal.site.config_sync_directory}';
 
 $settings['hash_salt'] = '${drupal.site.hash_salt}';
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
 $settings['container_yamls'][] = __DIR__ . '/services.build.yml';
 
 $settings['file_public_path'] = '${drupal.site.settings.file_public_path}';
 $settings['file_private_path'] = '${drupal.site.settings.file_private_path}';
+
+// Disable the render cache.
+$settings['cache']['bins']['render'] = 'cache.backend.null';
+
+// Disable the dynamic page cache.
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
 
 // Disable CSS and JS aggregation.
 $config['system.performance']['css']['preprocess'] = FALSE;


### PR DESCRIPTION
Addresses #20.

This file (`drupal.settings.build.php`) is only used on local and CI environments. Acquia, Pantheon, and Platform.sh environments use an entirely separate settings file template.