### PR TITLE
Allow configuring what command to use for running composer in the artifact

### DIFF
--- a/defaults.properties.yml
+++ b/defaults.properties.yml
@@ -236,6 +236,7 @@ phpmd:
   # File extensions to review.
   suffixes: php,inc,module,theme,profile,install,test
 
+
 # Configuration for running behat tests.
 #
 # Putting these flags in configuration allows you to vary the behat configuration per
@@ -248,3 +249,11 @@ phpmd:
 #     http://docs.behat.org/en/v2.5/guides/7.config.html#profiles)
 behat:
   args: "--suite=default --strict"
+
+
+# Configuration for composer.
+#
+# Use this configuration if you're running on an environment where composer is not available on the command line as
+# `composer` or `composer.phar`.
+# composer:
+#   composer: ${build.thebuild.dir}/vendor/bin/composer.phar

--- a/defaults.properties.yml
+++ b/defaults.properties.yml
@@ -253,7 +253,8 @@ behat:
 
 # Configuration for composer.
 #
-# Use this configuration if you're running on an environment where composer is not available on the command line as
-# `composer` or `composer.phar`.
+# Use this configuration if you're running on an environment where composer is not
+# available on the command line as `composer` or `composer.phar`. In some cases, you may
+# need to add composer to your project itself with `composer require composer/composer`.
 # composer:
-#   composer: ${build.thebuild.dir}/vendor/bin/composer.phar
+#   composer: /path/to/composer.phar

--- a/tasks/artifact.xml
+++ b/tasks/artifact.xml
@@ -230,7 +230,7 @@
 
     <target name="artifact-build">
         <echo>Installing composer dependencies in the artifact...</echo>
-        <composer command="install">
+        <composer command="install" composer="${composer.composer}">
             <arg line="--no-interaction --no-dev --working-dir=${artifact.directory}" />
         </composer>
 

--- a/tasks/artifact.xml
+++ b/tasks/artifact.xml
@@ -230,7 +230,9 @@
 
     <target name="artifact-build">
         <echo>Installing composer dependencies in the artifact...</echo>
-        <exec dir="${artifact.directory}" command="composer install --no-interaction --no-dev" checkreturn="true" />
+        <composer command="install">
+            <arg line="--no-interaction --no-dev --working-dir=${artifact.directory}" />
+        </composer>
 
         <echo>Deleting .git subdirectories added by Composer...</echo>
         <delete includeemptydirs="true">

--- a/tasks/the-build.xml
+++ b/tasks/the-build.xml
@@ -91,6 +91,19 @@
     <property name="drush.config" value="${build.dir}/drush/drushrc.php" />
 
 
+    <!-- Configure the composer command, depending on whether `composer` or `composer.phar` is available. -->
+    <exec command="command -V composer" returnProperty="composer.not_available.composer" />
+    <exec command="command -V composer.phar" returnProperty="composer.not_available.composer_phar" />
+    <if>
+        <isfalse value="${composer.not_available.composer}" />
+        <then><property name="composer.composer" value="composer" /></then>
+    </if>
+    <if>
+        <isfalse value="${composer.not_available.composer_phar}" />
+        <then><property name="composer.composer" value="composer.phar" /></then>
+    </if>
+
+
     <!--
         Default target: the-build
         This target is included only because the <project> tag requires it.


### PR DESCRIPTION
Resolves #23 -- though it requires that you add a bit of configuration if you don't have the `composer` or `composer.phar` commands available globally.