### PR TITLE
Add a "code-fix" target to automatically fix code violations

### DIFF
--- a/defaults/templates/the-build/build.xml
+++ b/defaults/templates/the-build/build.xml
@@ -141,7 +141,16 @@
         <exec command="${phpmd.command}" logoutput="true" checkreturn="true" />
     </target>
 
+  
+    <!-- Target: code-fix -->
+    <target name="code-fix" description="Run the automated code fixer.">
+        <!-- Run PHP Code Beautifier and Fixer. -->
+        <property name="phpcbf.command" value="vendor/bin/phpcbf --standard=${phpcs.standard} --ignore=${phpcs.ignore} ${phpcs.directories}" />
+        <echo msg="$> ${phpcbf.command}" />
+        <exec command="${phpcbf.command}" logoutput="true" checkreturn="false" />
+    </target>
 
+  
     <!-- Target: artifact -->
     <target name="artifact" description="Build and deploy the application.">
         <phing phingfile="build.xml" target="artifact-main" inheritAll="false">


### PR DESCRIPTION
The `code-review` task runs the PHP Code Sniffer which logs coding standard violations. It is possible to automatically fix these errors, but doing so requires running a long command. This PR adds a target called `code-review` to fix violations that PHPCBF can address automatically.

Resources:
- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically#using-the-php-code-beautifier-and-fixer