### PR TITLE
Drush aliases for automatically created multisites

### DIFF
--- a/defaults/templates/projectname.aliases.drushrc.php
+++ b/defaults/templates/projectname.aliases.drushrc.php
@@ -8,4 +8,5 @@ $aliases['local'] = [
   'uri' => '${drupal.sites.default.uri}',
 ];
 
+// Multisites created by `phing drupal-add-multisite` will be automatically added here.
 // @multisite_placeholder@

--- a/defaults/templates/projectname.aliases.drushrc.php
+++ b/defaults/templates/projectname.aliases.drushrc.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @file
+ * Drush aliases for this project.
+ */
+
+$aliases['local'] = [
+  'uri' => '${drupal.sites.default.uri}',
+];
+
+// @multisite_placeholder@

--- a/defaults/templates/the-build/build.default.properties.yml
+++ b/defaults/templates/the-build/build.default.properties.yml
@@ -35,7 +35,7 @@ drupal:
       database:
         database: "drupal"
 
-    # Add more multisites here.
+    # Multisites created by `phing drupal-add-multisite` will be automatically added here.
     # @multisite_placeholder@
 
     # Defaults for all sites; these can be overridden for individual sites.

--- a/defaults/templates/the-build/build.default.properties.yml
+++ b/defaults/templates/the-build/build.default.properties.yml
@@ -36,9 +36,7 @@ drupal:
         database: "drupal"
 
     # Add more multisites here.
-#   second:
-#     dir: second
-#     uri: "http://second.local"
+    # @multisite_placeholder@
 
     # Defaults for all sites; these can be overridden for individual sites.
     _defaults:

--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -387,23 +387,43 @@ $sites['${_multisite.sites_php_domain}'] = '${_multisite.dir}';
             </filterchain>
         </property>
 
-        <!--
-            There are still some manual steps, so print lots of information for the user.
-            -->
+        <property name="_multisite.config">@multisite_placeholder@
+    ${_multisite.key}:
+      dir: ${_multisite.dir}
+      uri: ${_multisite.uri}
+      hash_salt: ${_multisite.hash_salt}</property>
 
-        <!-- Whitespace is intentional. -->
-        <echo>
+        <reflexive file=".the-build/build.default.properties.yml">
+            <filterchain>
+                <replacetokens>
+                    <token key="multisite_placeholder" value="${_multisite.config}" />
+                </replacetokens>
+            </filterchain>
+        </reflexive>
+
+        <!-- If the '@multisite_placeholder@' is missing from the default properties file, the developer will have to
+             add the configuration manually. -->
+        <exec command="grep '@multisite_placeholder@' .the-build/build.default.properties.yml" returnProperty="_multisite.placeholder_missing" />
+        <if>
+            <equals arg1="${_multisite.placeholder_missing}" arg2="1" />
+            <then>
+                <!-- Whitespace is intentional. -->
+                <echo>
 
 To build and install this site, you need to add the following configuration to your .the-build/build.default.properties.yml file:
 
 drupal:
   sites:
-    ${_multisite.key}:
-      dir: ${_multisite.dir}
-      uri: ${_multisite.uri}
-      hash_salt: ${_multisite.hash_salt}
+    # ${_multisite.config}
+                </echo>
+            </then>
+        </if>
 
-Finally, install the new multisite with: `phing install -Dbuild.site=${_multisite.key}`
+
+        <!-- Whitespace is intentional. -->
+        <echo>
+
+Finally, you can install the new multisite with: `phing install -Dbuild.site=${_multisite.key}`
 
 You should also consider:
   * Adding the domain for your new multisite to your development environment configuration

--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -387,6 +387,7 @@ $sites['${_multisite.sites_php_domain}'] = '${_multisite.dir}';
             </filterchain>
         </property>
 
+        <!-- Add the multisite configuration to the default build properties file. -->
         <property name="_multisite.config">@multisite_placeholder@
     ${_multisite.key}:
       dir: ${_multisite.dir}
@@ -397,19 +398,6 @@ $sites['${_multisite.sites_php_domain}'] = '${_multisite.dir}';
             <filterchain>
                 <replacetokens>
                     <token key="multisite_placeholder" value="${_multisite.config}" />
-                </replacetokens>
-            </filterchain>
-        </reflexive>
-
-        <property name="_multisite.drush_alias">@multisite_placeholder@
-  $aliases['local.${_multisite.key}'] = [
-    'uri' => '${_multisite.uri}',
-  ];</property>
-
-        <reflexive file="drush/${projectname}.aliases.drushrc.php">
-            <filterchain>
-                <replacetokens>
-                    <token key="multisite_placeholder" value="${_multisite.drush_alias}" />
                 </replacetokens>
             </filterchain>
         </reflexive>
@@ -432,16 +420,29 @@ drupal:
             </then>
         </if>
 
+        <!-- Add a Drush alias for the multisite. -->
+        <property name="_multisite.drush_alias">@multisite_placeholder@
+  $aliases['local.${_multisite.key}'] = [
+    'uri' => '${_multisite.uri}',
+  ];</property>
+
+        <reflexive file="drush/${projectname}.aliases.drushrc.php">
+            <filterchain>
+                <replacetokens>
+                    <token key="multisite_placeholder" value="${_multisite.drush_alias}" />
+                </replacetokens>
+            </filterchain>
+        </reflexive>
 
         <!-- Whitespace is intentional. -->
         <echo>
 
 Finally, you can install the new multisite with: `phing install -Dbuild.site=${_multisite.key}`
 
-You should also consider:
-  * Adding the domain for your new multisite to your development environment configuration
-  * Creating a new 'profile' in your behat.yml configuration, and updating your behat.args property
-  * Updating your .circleci/config.yml to run tests for your new multisite</echo>
+You may also need to:
+  * Add the domain for your new multisite to your development environment configuration
+  * Create a new 'profile' in your behat.yml configuration, and updating your behat.args property
+  * Update your .circleci/config.yml to run tests for your new multisite</echo>
     </target>
 
 

--- a/tasks/drupal.xml
+++ b/tasks/drupal.xml
@@ -401,6 +401,19 @@ $sites['${_multisite.sites_php_domain}'] = '${_multisite.dir}';
             </filterchain>
         </reflexive>
 
+        <property name="_multisite.drush_alias">@multisite_placeholder@
+  $aliases['local.${_multisite.key}'] = [
+    'uri' => '${_multisite.uri}',
+  ];</property>
+
+        <reflexive file="drush/${projectname}.aliases.drushrc.php">
+            <filterchain>
+                <replacetokens>
+                    <token key="multisite_placeholder" value="${_multisite.drush_alias}" />
+                </replacetokens>
+            </filterchain>
+        </reflexive>
+
         <!-- If the '@multisite_placeholder@' is missing from the default properties file, the developer will have to
              add the configuration manually. -->
         <exec command="grep '@multisite_placeholder@' .the-build/build.default.properties.yml" returnProperty="_multisite.placeholder_missing" />

--- a/tasks/install.xml
+++ b/tasks/install.xml
@@ -162,8 +162,13 @@
         <copy todir="${application.startdir}/.the-build" file="${phing.dir.install}/../defaults/templates/drupal.services.build.yml" />
         <copy todir="${application.startdir}/.the-build" file="${phing.dir.install}/../defaults/templates/drupal.settings.build.php" />
 
-        <!-- Copy Drush configuration. -->
+        <!-- Copy Drush configuration and aliases file templates. -->
         <copy file="${phing.dir.install}/../defaults/templates/drushrc.php" tofile="${application.startdir}/drush/drushrc.php" overwrite="true">
+            <filterchain>
+                <expandproperties />
+            </filterchain>
+        </copy>
+        <copy file="${phing.dir.install}/../defaults/templates/projectname.aliases.drushrc.php" tofile="${application.startdir}/drush/${projectname}.aliases.drushrc.php" overwrite="true">
             <filterchain>
                 <expandproperties />
             </filterchain>


### PR DESCRIPTION
Addresses #105.

* Creates a drush aliases file in `drush/` when installing the-build
* Adds a new alias to the drush alias file when creating a new multisite
* Adds the multisite config to the-build's properties file automatically

To test:

1. Install the-build with `vendor/bin/the-build-installer`
2. Run `drush sa` -- it should list a `sitename.local` alias for your site
3. Create a new multisite with `phing drupal-add-multisite`
4. Run `drush sa` again -- there should be a new `sitename.local.NEWSITE` alias for your new multisite
5. Also, your `.the-build/build.default.properties.yml` file should have the Drupal sites configuration for your new multisite

A couple notes...
* This code got super messy because whitespace within XML is awkward