### PR TITLE
Style guide build commands - for release-2.0

### DIFF
--- a/defaults.properties.yml
+++ b/defaults.properties.yml
@@ -272,3 +272,14 @@ behat:
 # need to add composer to your project itself with `composer require composer/composer`.
 # composer:
 #   composer: /path/to/composer.phar
+
+
+# Configuration for building the style guide.
+#
+# Use these properties if you're using a Composer + Yarn install process for your
+# style guide and need to customize the location or the build command.
+styleguide:
+  # Location of the style guide, relative to the project root.
+  root: 'styleguide'
+  # Command to compile the style guide assets, for use during the build and artifact steps.
+  command: 'yarn default'

--- a/defaults/templates/the-build/build.xml
+++ b/defaults/templates/the-build/build.xml
@@ -23,10 +23,11 @@
     <!-- Additional optional targets. -->
     <import file="vendor/palantirnet/the-build/tasks/artifact.xml" />
     <import file="vendor/palantirnet/the-build/tasks/acquia.xml" />
+    <import file="vendor/palantirnet/the-build/tasks/styleguide.xml" />
 
 
     <!-- Default target: build -->
-    <target name="build" depends="set-site" description="Build the application.">
+    <target name="build" depends="styleguide,set-site" description="Build the application.">
         <!-- Create the Drupal custom code directories. -->
         <foreach list="${drupal.create_dirs}" param="dir" target="mkdir" />
 

--- a/tasks/styleguide.xml
+++ b/tasks/styleguide.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+
+<!--
+  @file styleguide.xml
+  Targets for managing the style guide.
+
+  Include this file in your build.xml with:
+    <import file="vendor/palantirnet/the-build/tasks/styleguide.xml" />
+
+  @see defaults.properties.yml
+
+  Copyright 2018 Palantir.net, Inc.
+  -->
+
+<project name="Styleguide" default="styleguide">
+
+    <fail unless="build.dir" />
+    <fail unless="build.env" />
+    <fail unless="projectname" />
+
+
+    <!-- Target: styleguide -->
+    <target name="styleguide" depends="styleguide-exists" description="Install and build the style guide.">
+        <if>
+            <equals arg1="${styleguide.exists}" arg2="1" />
+            <then>
+                <phingcall target="styleguide-build" />
+            </then>
+            <else>
+                <echo>Skipping style guide build.</echo>
+            </else>
+        </if>
+    </target>
+
+
+    <!--
+        Target: styleguide-exists
+
+        Check whether the styleguide directory exists and has the composer and yarn files that we expect.
+        -->
+    <target name="styleguide-exists">
+        <resolvepath propertyName="styleguide.root.resolved" file="${styleguide.root}" dir="${build.dir}" />
+        <echo>Looking for style guide at '${styleguide.root.resolved}'</echo>
+
+        <if>
+            <and>
+                <available file="${styleguide.root.resolved}" type="dir" />
+                <available file="${styleguide.root.resolved}/composer.json" type="file" />
+                <available file="${styleguide.root.resolved}/composer.lock" type="file" />
+                <available file="${styleguide.root.resolved}/package.json" type="file" />
+                <available file="${styleguide.root.resolved}/yarn.lock" type="file" />
+            </and>
+            <then>
+                <property name="styleguide.exists" value="1" />
+                <echo>Style guide found.</echo>
+            </then>
+            <else>
+                <echo>No style guide found.</echo>
+            </else>
+        </if>
+    </target>
+
+
+    <!--
+        Target: styleguide-exists-or-else
+
+        Fail if the styleguide does not exist.
+        -->
+    <target name="styleguide-exists-or-else" depends="styleguide-exists">
+        <if>
+            <not><equals arg1="${styleguide.exists}" arg2="1" /></not>
+            <then>
+                <fail message="Style guide not found at '${styleguide.root}'" />
+            </then>
+        </if>
+    </target>
+
+
+    <!--
+        Target: styleguide-build
+
+        Install and build the style guide.
+        -->
+    <target name="styleguide-build" depends="styleguide-exists-or-else,styleguide-install">
+        <echo>Running build command in ${styleguide.root}: ${styleguide.command}</echo>
+        <exec dir="${styleguide.root.resolved}" command="${styleguide.command}" passthru="true" checkreturn="true" />
+    </target>
+
+
+    <!--
+        Target: styleguide-install
+
+        Install the styleguide dependencies with composer and yarn.
+        -->
+    <target name="styleguide-install" depends="styleguide-exists-or-else">
+        <!-- Run composer install in the styleguide. -->
+        <if>
+            <and>
+                <available file="${styleguide.root.resolved}/composer.lock" type="file" />
+                <not><available file="${styleguide.root.resolved}/vendor/autoload.php" type="file" /></not>
+            </and>
+            <then>
+                <exec dir="${styleguide.root.resolved}" command="composer install --no-interaction" passthru="true" checkreturn="true" />
+            </then>
+        </if>
+
+        <!-- Run yarn install in the styleguide. -->
+        <if>
+            <and>
+                <available file="${styleguide.root.resolved}/yarn.lock" type="file" />
+                <or>
+                  <not><available file="${styleguide.root.resolved}/node_modules/.yarn-integrity" type="file" /></not>
+                  <not><available file="${styleguide.root.resolved}/node_modules/node-sass/vendor/linux-x64-59/binding.node" type="file" /></not>
+                </or>
+            </and>
+            <then>
+                <exec dir="${styleguide.root.resolved}" command="yarn install --non-interactive --no-progress --prefer-offline" passthru="true" checkreturn="true" />
+            </then>
+        </if>
+    </target>
+
+
+</project>


### PR DESCRIPTION
Addresses #106; see also #93.

Testing:

1. Reinstall the-build (`vendor/bin/the-build-installer`)
2. If there is a `styleguide/` present, the styleguide should be built
3. If there is not, everything should proceed as before.