### PR TITLE
121: Update url to platformsh default settings file in install target

### DIFF
--- a/tasks/install.xml
+++ b/tasks/install.xml
@@ -263,7 +263,7 @@
             </case>
 
             <case value="platformsh">
-                <httpget url="https://raw.githubusercontent.com/platformsh/platformsh-example-drupal8/master/web/sites/default/settings.platformsh.php" dir="${build.dir}/${drupal.root}/sites/${drupal.site.dir}" />
+                <httpget url="https://raw.githubusercontent.com/platformsh/template-drupal8/master/web/sites/default/settings.platformsh.php" dir="${build.dir}/${drupal.root}/sites/${drupal.site.dir}" />
             </case>
             <default />
         </switch>


### PR DESCRIPTION
Addresses #121 by updating the URL used to get the platformsh default settings file from github in the install target.

### To test

Follow the steps to create a new site from the `drupal-skeleton` to enable development on `the-build`: https://github.com/palantirnet/the-build/blob/6870f6713305c2b0de0feaf94b74bcaaff13bfa2/docs/development.md#creating-a-new-site-for-testing

Note: use this branch instead of `release-2.0` by running `composer require palantirnet/the-build:dev-121-update-platformsh-settings-url --prefer-source` before step 3 of the quick start guide
