### PR TITLE
Platform.sh environment

### DIFF
--- a/defaults/install/drupal/settings.build-platformsh.php
+++ b/defaults/install/drupal/settings.build-platformsh.php
@@ -5,6 +5,9 @@
  * Drupal settings file template for use on Platform.sh environments.
  */
 
+$config_directories = [];
+$config_directories[CONFIG_SYNC_DIRECTORY] = '${drupal.site.config_sync_directory}';
+
 // Enable/disable config_split configurations.
 if (isset($_ENV['PLATFORM_BRANCH'])) {
   if ($_ENV['PLATFORM_BRANCH'] == 'master') {

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -154,6 +154,7 @@
                 <copy todir="${application.startdir}/.platform" overwrite="true">
                     <fileset dir="${build.thebuild.dir}/defaults/install/.platform" />
                 </copy>
+                <httpget url="https://raw.githubusercontent.com/platformsh/template-drupal8/master/.environment" dir="${build.dir}/" />
             </case>
             <default />
         </switch>


### PR DESCRIPTION
Two fixes for deploying to Platform.sh:

* Set the config directory in the Drupal settings file template for Platform.sh
* Include the `.environment` file so that we can run commands from `vendor/bin/` on Platform.sh 