### PR TITLE
Refs #129: Adds drupal-check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/cleanup
+    working_directory: ~/example
     docker:
       - image: circleci/php:7.1-node-browsers
       - image: circleci/mysql:5.7-ram
@@ -62,10 +62,26 @@ jobs:
             - source-v1-{{ .Branch }}
             - source-v1-
 
-      - checkout
+      # Create a new project using the drupal-skeleton project
       - run:
-          name: Composer install
-          command: composer install --no-interaction --prefer-dist
+          name: Create a new Drupal project
+          command: composer create-project palantirnet/drupal-skeleton example dev-drupal8 --no-interaction
+          working_directory: ~/
+
+      # Use this copy of the-build
+      - run:
+          name: Replace the default version of the-build with this one
+          command: rm -r vendor/palantirnet/the-build
+
+      - checkout:
+          path: ~/example/vendor/palantirnet/the-build
+
+      # Source cache - update when branch changes
+      - save_cache:
+          key: source-v1-{{ .Branch }}
+          paths:
+            - ".git"
+
 
       # Composer package cache - update when the contents of the Composer cache directory
       # change
@@ -74,36 +90,33 @@ jobs:
           key: composer-v1-{{ checksum "/tmp/composer-cache.txt" }}
           paths:
               - ~/.composer
-      # Source cache - update when branch changes
-      - save_cache:
-          key: source-v1-{{ .Branch }}
-          paths:
-            - ".git"
 
-      # Run code reviews before installing Drupal, so that tests fail earlier.
+
+      # Install the-build
       - run:
-          name: Run code reviews
-          command: vendor/bin/phing code-review
+          name: Install the-build in the project
+          command: printf 'http://the-build.local\nother\nn' | vendor/bin/the-build-installer
 
       - run:
           name: Wait for DB
           # Dockerize is preinstalled in circleci/* docker image
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
 
-      - run:
-          name: Build Drupal's settings.php
-          command: vendor/bin/phing build
+      # Install Drupal (separately, so that we can see it fail separately)
       - run:
           name: Install Drupal
-          command: vendor/bin/phing install
+          command: printf 'y' | vendor/bin/phing install -Ddrupal.validate_clean_config.bypass=yes
+
+      # Add a multisite
       - run:
-          name: Run any migrations
-          command: vendor/bin/phing migrate
+          name: Add a multisite to the project
+          command: printf 'intranet\nintranet.the-build.local' | vendor/bin/phing drupal-add-multisite
+
       - run:
           name: Run Behat tests
           command: |
               nohup php -S ${CIRCLE_PROJECT_REPONAME}.local:8000 -t $(pwd)/${DRUPAL_ROOT}/ > /tmp/artifacts/phpd.log 2>&1 &
-              vendor/bin/phing test
+              vendor/bin/phing test -Dbuild.env=circleci
 
       - store_artifacts:
           path: /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/example
+    working_directory: ~/cleanup
     docker:
       - image: circleci/php:7.1-node-browsers
       - image: circleci/mysql:5.7-ram
@@ -43,6 +43,15 @@ jobs:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
 
+      # Note: phing and drupal-check have mutually exclusive requirements.
+      # It'd be better to add drupal-check as a dependency of the drupal project
+      # rather than as part of the virtual environment, but this will have to do
+      # for now. Also note, drupal-check is added as part of the-vagrant so it
+      # is available to run within our VM.
+      - run:
+          name: Install drupal-check
+          command: composer global require mglaman/drupal-check
+
       # Composer package cache
       - restore_cache:
           keys:
@@ -53,26 +62,10 @@ jobs:
             - source-v1-{{ .Branch }}
             - source-v1-
 
-      # Create a new project using the drupal-skeleton project
+      - checkout
       - run:
-          name: Create a new Drupal project
-          command: composer create-project palantirnet/drupal-skeleton example dev-drupal8 --no-interaction
-          working_directory: ~/
-
-      # Use this copy of the-build
-      - run:
-          name: Replace the default version of the-build with this one
-          command: rm -r vendor/palantirnet/the-build
-
-      - checkout:
-          path: ~/example/vendor/palantirnet/the-build
-
-      # Source cache - update when branch changes
-      - save_cache:
-          key: source-v1-{{ .Branch }}
-          paths:
-            - ".git"
-
+          name: Composer install
+          command: composer install --no-interaction --prefer-dist
 
       # Composer package cache - update when the contents of the Composer cache directory
       # change
@@ -81,33 +74,36 @@ jobs:
           key: composer-v1-{{ checksum "/tmp/composer-cache.txt" }}
           paths:
               - ~/.composer
+      # Source cache - update when branch changes
+      - save_cache:
+          key: source-v1-{{ .Branch }}
+          paths:
+            - ".git"
 
-
-      # Install the-build
+      # Run code reviews before installing Drupal, so that tests fail earlier.
       - run:
-          name: Install the-build in the project
-          command: printf 'http://the-build.local\nother\nn' | vendor/bin/the-build-installer
+          name: Run code reviews
+          command: vendor/bin/phing code-review
 
       - run:
           name: Wait for DB
           # Dockerize is preinstalled in circleci/* docker image
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
 
-      # Install Drupal (separately, so that we can see it fail separately)
+      - run:
+          name: Build Drupal's settings.php
+          command: vendor/bin/phing build
       - run:
           name: Install Drupal
-          command: printf 'y' | vendor/bin/phing install -Ddrupal.validate_clean_config.bypass=yes
-
-      # Add a multisite
+          command: vendor/bin/phing install
       - run:
-          name: Add a multisite to the project
-          command: printf 'intranet\nintranet.the-build.local' | vendor/bin/phing drupal-add-multisite
-
+          name: Run any migrations
+          command: vendor/bin/phing migrate
       - run:
           name: Run Behat tests
           command: |
               nohup php -S ${CIRCLE_PROJECT_REPONAME}.local:8000 -t $(pwd)/${DRUPAL_ROOT}/ > /tmp/artifacts/phpd.log 2>&1 &
-              vendor/bin/phing test -Dbuild.env=circleci
+              vendor/bin/phing test
 
       - store_artifacts:
           path: /tmp/artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## Release 2.0.1
+
+### Fixed
+
+* Fixed `settings.php` and environment configuration for Platform.sh (#126, #131)
+* Fixed bugs with first runs of `phing acquia-get-backup` (#132)
+* Removed deprecated config for testing the `palantirnet/drupal-skeleton` project (#128)
+
+
 ## Release 2.0
 
 This release has several core architectural changes:

--- a/defaults.yml
+++ b/defaults.yml
@@ -253,10 +253,13 @@ phpmd:
 # Configuration for checking the site with the Drupal Checker code linter.
 #
 # @see https://github.com/mglaman/drupal-check
-# These values are used in the build.dist.xml template:
+# These values are used in the defaults/build.xml template.
 drupal-check:
-  # Space seperated list of directories
-  directories: "${drupal.root}/modules/custom/ ${drupal.root}/themes/custom/ ${drupal.root}/profiles/custom/"
+  # Location of the drupal-check script. This script is currently installed globally
+  # because of repository-level composer conflicts.
+  bin: "~/bin/drupal-check"
+  # Comma separated list of directories
+  directories: "${drupal.root}/modules/custom/,${drupal.root}/themes/custom/,${drupal.root}/profiles/custom/"
 
 # Configuration for running behat tests.
 #

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -142,7 +142,7 @@
         <exec command="${phpmd.command}" logoutput="true" checkreturn="true" />
 
         <!-- Run Drupal Check. -->
-        <property name="drupal-check.command" value="drupal-check ${drupal-check.directories}" />
+        <property name="drupal-check.command" value="/home/circleci/.composer/vendor/bin/drupal-check ${drupal-check.directories}" />
         <echo msg="$> ${drupal-check.command}" />
         <exec command="${drupal-check.command}" logoutput="true" checkreturn="true" />
     </target>

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -142,7 +142,15 @@
         <exec command="${phpmd.command}" logoutput="true" checkreturn="true" />
 
         <!-- Run Drupal Check. -->
-        <property name="drupal-check.command" value="/home/circleci/.composer/vendor/bin/drupal-check ${drupal-check.directories}" />
+        <foreach list="${drupal-check.directories}" param="drupal-check.dir" target="drupal-check" />
+    </target>
+
+
+    <!-- Separated out so that we can use foreach. drupal-check only accepts a single directory argument. -->
+    <target name="drupal-check">
+        <fail unless="drupal-check.dir" />
+        <property name="drupal-check.bin" value="~/bin/drupal-check" />
+        <property name="drupal-check.command" value="${drupal-check.bin} ${drupal-check.dir}" />
         <echo msg="$> ${drupal-check.command}" />
         <exec command="${drupal-check.command}" logoutput="true" checkreturn="true" />
     </target>

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -140,14 +140,14 @@
         <property name="phpmd.command" value="vendor/bin/phpmd ${phpmd.directories} ${phpmd.format} ${phpmd.rulesets} --suffixes=${phpmd.suffixes}" />
         <echo msg="$> ${phpmd.command}" />
         <exec command="${phpmd.command}" logoutput="true" checkreturn="true" />
-      
+
         <!-- Run Drupal Check. -->
-        <property name="drupal-check.command" value="vendor/bin/drupal-check ${drupal-check.directories}" />
+        <property name="drupal-check.command" value="drupal-check ${drupal-check.directories}" />
         <echo msg="$> ${drupal-check.command}" />
         <exec command="${drupal-check.command}" logoutput="true" checkreturn="true" />
     </target>
 
-  
+
     <!-- Target: code-fix -->
     <target name="code-fix" description="Run the automated code fixer.">
         <!-- Run PHP Code Beautifier and Fixer. -->
@@ -156,7 +156,7 @@
         <exec command="${phpcbf.command}" logoutput="true" checkreturn="false" />
     </target>
 
-  
+
     <!-- Target: artifact -->
     <target name="artifact" description="Build and deploy the application.">
         <phing phingfile="build.xml" target="artifact-main" inheritAll="false">

--- a/defaults/install/the-build/build.circleci.yml
+++ b/defaults/install/the-build/build.circleci.yml
@@ -13,3 +13,6 @@ drupal:
 
 behat:
   args: "--profile=circleci --suite=default --strict --format=junit --out=/tmp/artifacts --tags=~@skipci"
+
+drupal-check:
+  bin: "/home/circleci/.composer/vendor/bin/drupal-check"

--- a/defaults/install/the-build/build.yml
+++ b/defaults/install/the-build/build.yml
@@ -51,6 +51,13 @@ drupal:
 behat:
   args: "--suite=default --strict"
 
+# Configuration for checking the site with the Drupal Checker code linter.
+drupal-check:
+  # Location of the drupal-check script. This script is currently installed globally
+  # on the-vagrant because of repository-level composer conflicts.
+  bin: "~/bin/drupal-check"
+
+
 # To build an artifact from your code, add the URL to your artifact git repository.
 # @see https://github.com/palantirnet/the-build/blob/release-2.0/defaults.yml
 #


### PR DESCRIPTION
To test this PR: provision a VM on CircleCI and see that `drupal-check` is installed globally for use in the VM.

This PR goes hand-in-hand with https://github.com/palantirnet/the-vagrant/pull/64.