### PR TITLE
Change package name for MySQL client on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - run:
           name: Install packages
-          command: sudo apt-get install -y libpng-dev mysql-client
+          command: sudo apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Install nvm
           command: |


### PR DESCRIPTION
On CircleCI, recently, the new PHP Docker image has been failing to install packages with the following error:
```
Package mysql-client is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'mysql-client' has no installation candidate
```

This updates the CircleCI config to install `default-mysql-client` instead, which fixes the issue.

See https://palantirnet.slack.com/archives/G89H0R8K0/p1563207554004500 and https://yourmystar-engineer.hatenablog.jp/entry/2019/07/15/140644

Also, compare https://circleci.com/gh/palantirnet/ntc/2613 to https://circleci.com/gh/palantirnet/ntc/2614 and note the change in https://github.com/palantirnet/ntc/commit/cca680a1d32ab2845eae9c6d296bca59290a8c33
