### PR TITLE
Hide internal phing targets from 'phing -l'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 * Preserve file permissions when building the artifact (#130 / #138)
+* Hide internal phing targets from `phing -l`, and update the default target in the build.xml template to run `phing -l` (#139)
 
 ## Release 2.1.1
 

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -10,7 +10,7 @@
   @see https://github.com/palantirnet/the-build
   -->
 
-<project name="@projectname@" default="build">
+<project name="@projectname@" default="list">
 
     <!-- Add property loading and targets from palantirnet/the-build. -->
     <import file="vendor/palantirnet/the-build/targets/the-build.xml" />
@@ -26,7 +26,7 @@
     <import file="vendor/palantirnet/the-build/targets/styleguide.xml" />
 
 
-    <!-- Default target: build -->
+    <!-- Target: build -->
     <target name="build" depends="styleguide,set-site" description="Build the application.">
         <!-- Create the Drupal custom code directories. -->
         <foreach list="${drupal.create_dirs}" param="dir" target="mkdir" />
@@ -81,7 +81,7 @@
          Run the build target for all configured multisites. This is the same as running:
            phing sites-run -Dtarget=build
          -->
-    <target name="build-all">
+    <target name="build-all" description="Run the 'build' target against all multisites.">
         <phingcall target="sites-run">
             <property name="target" value="build" />
         </phingcall>
@@ -92,7 +92,7 @@
          Run the install target for all configured multisites. This is the same as running:
            phing sites-run -Dtarget=install
          -->
-    <target name="install-all">
+    <target name="install-all" description="Run the 'install' target against all multisites.">
         <phingcall target="sites-run">
             <property name="target" value="install" />
         </phingcall>
@@ -147,7 +147,7 @@
 
 
     <!-- Separated out so that we can use foreach. drupal-check only accepts a single directory argument. -->
-    <target name="drupal-check">
+    <target name="drupal-check" hidden="true">
         <fail unless="drupal-check.dir" />
         <property name="drupal-check.bin" value="~/bin/drupal-check" />
         <property name="drupal-check.command" value="${drupal-check.bin} ${drupal-check.dir}" />
@@ -170,6 +170,15 @@
         <phing phingfile="build.xml" target="artifact-main" inheritAll="false">
             <property name="build.env" value="@host@" />
         </phing>
+    </target>
+
+
+    <!-- Default target: list -->
+    <target name="list" hidden="true">
+        <exec command="phing -q -f ${phing.file} -l" passthru="true"/>
+        <echo>Find more documentation for palantirnet/the-build on GitHub:
+
+            https://github.com/palantirnet/the-build#using-the-build</echo>
     </target>
 
 

--- a/targets/artifact.xml
+++ b/targets/artifact.xml
@@ -18,7 +18,7 @@
 
       Build and deploy the application.
       -->
-    <target name="artifact-main">
+    <target name="artifact-main" hidden="true">
         <!-- This property MUST be provided. -->
         <fail unless="artifact.git.remote" message="The remote git repository must be configured in the 'artifact.git.remote' property." />
 
@@ -67,7 +67,7 @@
     </target>
 
 
-    <target name="artifact-safeToBuild">
+    <target name="artifact-safeToBuild" hidden="true">
         <!-- Make sure the caller is using a deployment environment. -->
         <echo>Deploy environment:   ${build.env}</echo>
         <if>
@@ -142,7 +142,7 @@
     </target>
 
 
-    <target name="artifact-initializeRepository">
+    <target name="artifact-initializeRepository" hidden="true">
         <fail unless="artifact.directory" />
         <fail unless="artifact.git.remote" />
 
@@ -163,7 +163,7 @@
     </target>
 
 
-    <target name="artifact-setupBranch">
+    <target name="artifact-setupBranch" hidden="true">
         <exec dir="${artifact.directory}" command="git fetch ${artifact.git.remote_name} ${artifact.git.remote_branch}" returnProperty="remote_fetch.error" />
         <if>
             <not><equals arg1="${remote_fetch.error}" arg2="0" /></not>
@@ -194,7 +194,7 @@
     </target>
 
 
-    <target name="artifact-updateCode">
+    <target name="artifact-updateCode" hidden="true">
         <!-- Remove all the existing files so that we can install cleanly. -->
         <delete includeemptydirs="true">
             <fileset dir="${artifact.directory}" defaultexcludes="false" excludes=".git,.git/**" includes="**/*,**/.git,**/.git/**" />
@@ -226,7 +226,7 @@
     </target>
 
 
-    <target name="artifact-build">
+    <target name="artifact-build" hidden="true">
         <echo>Installing composer dependencies in the artifact...</echo>
         <composer command="install" composer="${composer.composer}">
             <arg line="--no-interaction --no-dev --working-dir=${artifact.directory}" />
@@ -243,7 +243,7 @@
     </target>
 
 
-    <target name="artifact-build-one">
+    <target name="artifact-build-one" hidden="true">
         <!--
             - Override the Drupal root so that it is within the artifact directory.
             - Override the "artifact mode" so that files managed with the
@@ -257,7 +257,7 @@
     </target>
 
 
-    <target name="artifact-commit">
+    <target name="artifact-commit" hidden="true">
         <!-- The 'allFiles' flag on the GitCommitTask does not add files that aren't already tracked by git. -->
         <exec command="git add --all" dir="${artifact.directory}" />
 
@@ -274,7 +274,7 @@
     </target>
 
 
-    <target name="artifact-finish">
+    <target name="artifact-finish" hidden="true">
         <selectone list="push,keep,discard" propertyName="artifact.result" message="Push artifact changes to the '${artifact.git.remote_branch}' branch?" />
 
         <if>
@@ -307,7 +307,7 @@
     </target>
 
 
-    <target name="artifact-push">
+    <target name="artifact-push" hidden="true">
         <echo>Pushing changes.</echo>
         <exec dir="${artifact.directory}" command="git push ${artifact.git.remote_name} ${artifact.git.temporary_branch}:${artifact.git.remote_branch}" checkreturn="true" />
 
@@ -321,7 +321,7 @@
     </target>
 
 
-    <target name="artifact-cleanupTag">
+    <target name="artifact-cleanupTag" hidden="true">
         <if>
             <equals arg1="${artifact.git.no_tag}" arg2="0" />
             <then>
@@ -331,7 +331,7 @@
     </target>
 
 
-    <target name="artifact-resetState">
+    <target name="artifact-resetState" hidden="true">
         <exec dir="${artifact.directory}" command="chmod -R 750 ." checkreturn="true" logoutput="true" />
         <exec dir="${artifact.directory}" command="git reset --hard HEAD" checkreturn="true" logoutput="true" />
         <exec dir="${artifact.directory}" command="git checkout ${artifact.git.remote_base_branch}" checkreturn="true" logoutput="true" />

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -27,7 +27,7 @@
         Validate that the Drupal config directory doesn't have local modifications,
         to ensure consistent installation.
     -->
-    <target name="drupal-validate-clean-config" depends="set-site">
+    <target name="drupal-validate-clean-config" depends="set-site" hidden="true">
       <!-- Assembling this property at run time. -->
       <property name="drupal.validate_clean_config.dir" value="${build.dir}/${drupal.root}/${drupal.site.config_sync_directory}" />
 
@@ -87,7 +87,7 @@ ${modified_files}
           - The site in maintenance mode
           - Structure only for cache, search, and log tables
         -->
-    <target name="drupal-dump-db" depends="set-site" description="Generate a database dump.">
+    <target name="drupal-dump-db" depends="set-site" description="Generate a database dump of the site in maintenance mode with a new admin password.">
         <fail unless="drupal.site.admin_user" />
 
         <!-- prompt for a prod admin password -->
@@ -180,9 +180,9 @@ Or, you can specify the export file directly:
     <!-- Target: drupal-has-database-connection
 
          Check for a Drupal database connection. If the database doesn't exist and we have
-         the permissions, it will be created.
+         the permissions, the database will be created.
          -->
-    <target name="drupal-has-database-connection" depends="set-site">
+    <target name="drupal-has-database-connection" depends="set-site" hidden="true">
         <trycatch>
             <try>
                 <drush command="sql-query">
@@ -214,7 +214,7 @@ Or, you can specify the export file directly:
 
          Check for Drupal config, and if it's not present, offer to install Drupal.
          -->
-    <target name="drupal-install-if-no-config" depends="set-site">
+    <target name="drupal-install-if-no-config" depends="set-site" hidden="true">
         <if>
             <!-- Check for the core.extension.yml config file, which is present in any
                  complete exported Drupal configuration. -->
@@ -252,7 +252,7 @@ Or, you can specify the export file directly:
          of the places where this is called from code already have separate dependencies
          on that target.
          -->
-    <target name="drupal-first-install" depends="set-site">
+    <target name="drupal-first-install" depends="set-site" hidden="true">
         <fail unless="drupal.site.admin_user" />
 
         <symlink link="${build.dir}/${drupal.root}/modules/contrib/the_build_utility" target="${build.thebuild.dir}/defaults/standard/modules/the_build_utility" />

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -221,13 +221,13 @@
 
             Successfully installed the-build. Next, you may want to run:
 
+              $> phing list
               $> phing install
-              $> phing test
-              $> phing -l</echo>
+              $> phing test</echo>
     </target>
 
 
-    <target name="drupal-sites-directory">
+    <target name="drupal-sites-directory" hidden="true">
         <fail unless="drupal.site.dir" />
         <fail unless="build.host" />
         <fail unless="drupal.root" />

--- a/targets/styleguide.xml
+++ b/targets/styleguide.xml
@@ -38,7 +38,7 @@
 
         Check whether the styleguide directory exists and has the composer and yarn files that we expect.
         -->
-    <target name="styleguide-exists">
+    <target name="styleguide-exists" hidden="true">
         <resolvepath propertyName="styleguide.root.resolved" file="${styleguide.root}" dir="${build.dir}" />
         <echo>Looking for style guide at '${styleguide.root.resolved}'</echo>
 
@@ -66,7 +66,7 @@
 
         Fail if the styleguide does not exist.
         -->
-    <target name="styleguide-exists-or-else" depends="styleguide-exists">
+    <target name="styleguide-exists-or-else" depends="styleguide-exists" hidden="true">
         <if>
             <not><equals arg1="${styleguide.exists}" arg2="1" /></not>
             <then>
@@ -81,7 +81,7 @@
 
         Install and build the style guide.
         -->
-    <target name="styleguide-build" depends="styleguide-exists-or-else,styleguide-install">
+    <target name="styleguide-build" depends="styleguide-exists-or-else,styleguide-install" hidden="true">
         <echo>Running build command in ${styleguide.root}: ${styleguide.command}</echo>
         <exec dir="${styleguide.root.resolved}" command="${styleguide.command}" passthru="true" checkreturn="true" />
     </target>
@@ -92,7 +92,7 @@
 
         Install the styleguide dependencies with composer and yarn.
         -->
-    <target name="styleguide-install" depends="styleguide-exists-or-else">
+    <target name="styleguide-install" depends="styleguide-exists-or-else" hidden="true">
         <!-- Run composer install in the styleguide. -->
         <if>
             <and>

--- a/targets/the-build.xml
+++ b/targets/the-build.xml
@@ -111,7 +111,7 @@
         Default target: the-build
         This target is included only because the <project> tag requires it.
         -->
-    <target name="the-build">
+    <target name="the-build" hidden="true">
         <echo>Hello! I'm the-build.</echo>
     </target>
 
@@ -120,7 +120,7 @@
         Target: set-site
         Set properties for the current site in 'drupal.site.*'.
         -->
-    <target name="set-site">
+    <target name="set-site" hidden="true">
         <!-- Use this custom task to figure out which site to build. -->
         <selectpropertykey prefix="drupal.sites." omitKeys="_defaults" propertyName="build.site" message="Select a site to build:" />
 
@@ -161,7 +161,7 @@
         Utility target used by 'all-sites' above. Runs the specified
         target in an isolated Phing environment.
         -->
-    <target name="sites-run-target">
+    <target name="sites-run-target" hidden="true">
         <fail unless="target" />
         <fail unless="site_key" />
         <echo msg="Running 'phing ${target} -Dbuild.site=${site_key}'" />
@@ -175,7 +175,7 @@
         Target: mkdir
         Utility target to allow creating a list of directories with <foreach />.
         -->
-    <target name="mkdir">
+    <target name="mkdir" hidden="true">
         <echo msg="${dir}" />
         <mkdir dir="${dir}" />
     </target>


### PR DESCRIPTION
See https://akrabat.com/a-few-phing-tips/

This shortens the output of `phing -l` and makes it behave more like `drush list`. There are also a few comment updates in here to clarify the purpose of some of the targets.

Also, now when you type just `phing`, it will provide a list of targets and a url to the documentation, rather than running the `build` target. This will only affect new installs, as it's a change to the `build.xml` template.