### PR TITLE
Update the config_sync_directory settings for Drupal 8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
 ### Changed
 
 * Updated from Drush 8 to Drush 9
+* Changed how the `config_sync_directory` is handled for Drupal 8.8 - see [drupal.org/node/3018145](https://www.drupal.org/node/3018145)
 
 ### Updating from 2.1
 
-This change requires a lot of dependency math! The easiest way to resolve it is to remove the-build from the requirements, and then re-add it.
+This version is only compatible with Drupal 8.8 and higher.
+
+The Drush update requires a lot of dependency math! The easiest way to resolve it is to remove the-build from the requirements, and then re-add it.
 
 ```
 composer remove --dev palantirnet/the-build

--- a/defaults/install/drupal/settings.build-acquia.php
+++ b/defaults/install/drupal/settings.build-acquia.php
@@ -12,8 +12,7 @@ $settings['file_public_path'] = '${drupal.site.settings.file_public_path}';
 $settings['file_private_path'] = "/mnt/gfs/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/files-private";
 $config['system.file']['path']['temporary'] = $_ENV['TEMP'];
 
-$config_directories = [];
-$config_directories[CONFIG_SYNC_DIRECTORY] = '${drupal.site.config_sync_directory}';
+$settings['config_sync_directory'] = '${drupal.site.config_sync_directory}';
 
 // Enable/disable config_split configurations.
 if (isset($_ENV['AH_PRODUCTION']) && $_ENV['AH_PRODUCTION']) {

--- a/defaults/install/drupal/settings.build-pantheon.php
+++ b/defaults/install/drupal/settings.build-pantheon.php
@@ -5,8 +5,7 @@
  * Drupal settings file template for use on Pantheon environments.
  */
 
-$config_directories = [];
-$config_directories[CONFIG_SYNC_DIRECTORY] = '${drupal.site.config_sync_directory}';
+$settings['config_sync_directory'] = '${drupal.site.config_sync_directory}';
 
 // Enable/disable config_split configurations.
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {

--- a/defaults/install/drupal/settings.build-platformsh.php
+++ b/defaults/install/drupal/settings.build-platformsh.php
@@ -5,8 +5,7 @@
  * Drupal settings file template for use on Platform.sh environments.
  */
 
-$config_directories = [];
-$config_directories[CONFIG_SYNC_DIRECTORY] = '${drupal.site.config_sync_directory}';
+$settings['config_sync_directory'] = '${drupal.site.config_sync_directory}';
 
 // Enable/disable config_split configurations.
 if (isset($_ENV['PLATFORM_BRANCH'])) {

--- a/defaults/install/drupal/settings.build.php
+++ b/defaults/install/drupal/settings.build.php
@@ -14,8 +14,7 @@ $databases['default']['default'] = array(
   'collation' => 'utf8mb4_general_ci',
 );
 
-$config_directories = array();
-$config_directories[CONFIG_SYNC_DIRECTORY] = '${drupal.site.config_sync_directory}';
+$settings['config_sync_directory'] = '${drupal.site.config_sync_directory}';
 
 $settings['hash_salt'] = '${drupal.site.hash_salt}';
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';


### PR DESCRIPTION
See https://www.drupal.org/node/3018145

Just one question: should we leave the old `$config_directories` variable in place to maintain compatibility with Drupal 8.7? That's why the tests are failing at the moment.