### PR TITLE
Upgrade to latest version of drupal/coder (8.3.6)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "palantirnet/phing-drush-task": "^1.1",
-        "drupal/coder": "~8.2.12",
+        "drupal/coder": "^8.3.6",
         "drush/drush": "^9.0",
         "pear/http_request2": "^2.3",
         "pear/versioncontrol_git": "@dev",


### PR DESCRIPTION
## Description

While working on https://github.com/palantirnet/drupal-skeleton/pull/101

I got an error that `coder` version in `the-build` is not compatible.

## Testing instructions

1. `composer install`
