### PR TITLE
Drush install from existing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 * Added Drupal 8.8's `$settings['file_temp_path']` configuration to settings.*.php (#144)
 
+### Changed
+
+* `phing install` now uses `drush site-install --existing-config` instead of the [config_installer profile](https://www.drupal.org/project/config_installer) (#145)
+
+### Deprecated
+
+* The `drupal.site.profile` property is no longer used by the default `install` target in `build.xml`. It will be removed in the 3.0 release. (#145)
+
 ## 2.2.1
 
 ### Changed

--- a/defaults.yml
+++ b/defaults.yml
@@ -95,7 +95,7 @@ drupal:
       hash_salt: temporary
 
       # Drupal install profile to use for the drupal-install target.
-      profile: config_installer
+      profile: standard
 
       # Drupal admin username, if you feel inclined to change it.
       admin_user: admin

--- a/defaults.yml
+++ b/defaults.yml
@@ -94,6 +94,14 @@ drupal:
       # `the-build`.
       hash_salt: temporary
 
+      # Drupal install profile to use for the drupal-install target.
+      #
+      # DEPRECATED - to be removed in 3.0
+      # This property was used in the 'install' target in the default build.xml, until
+      # we switched from the config_installer profile to using
+      # 'drush site-install --existing-config`.
+      profile: config_installer
+
       # Drupal admin username, if you feel inclined to change it.
       admin_user: admin
 

--- a/defaults.yml
+++ b/defaults.yml
@@ -94,9 +94,6 @@ drupal:
       # `the-build`.
       hash_salt: temporary
 
-      # Drupal install profile to use for the drupal-install target.
-      profile: standard
-
       # Drupal admin username, if you feel inclined to change it.
       admin_user: admin
 

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -72,7 +72,7 @@
             <option name="site-name">${projectname}</option>
             <option name="account-name">${drupal.site.admin_user}</option>
             <option name="account-pass">admin</option>
-            <param>${drupal.site.profile}</param>
+            <option name="existing-config" />
         </drush>
     </target>
 

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -269,28 +269,11 @@ Or, you can specify the export file directly:
             <option name="site-name">${projectname}</option>
             <option name="account-name">${drupal.site.admin_user}</option>
             <option name="account-pass">admin</option>
-            <param>standard</param>
+            <param>${drupal.site.profile}</param>
         </drush>
 
         <drush command="pm-enable" assume="yes">
             <param>the_build_utility</param>
-        </drush>
-
-        <drush command="config-delete" assume="yes">
-            <param>core.extension</param>
-            <param>module.standard</param>
-        </drush>
-
-        <drush command="config-set" assume="yes">
-            <param>core.extension</param>
-            <param>module.config_installer</param>
-            <param>1000</param>
-        </drush>
-
-        <drush command="config-set" assume="yes">
-            <param>core.extension</param>
-            <param>profile</param>
-            <param>config_installer</param>
         </drush>
 
         <drush command="pm-uninstall" assume="yes">
@@ -302,7 +285,7 @@ Or, you can specify the export file directly:
         <!-- Whitespace is intentional. -->
         <echo>
 
-             Drupal has been installed with the install profile "standard". Future installs will be run using config_installer.
+             Drupal has been installed with the install profile "${drupal.site.profile}". Future installs will be run using 'drush site:install --existing-config'.
 
              Your config has been exported to ${drupal.root}/${drupal.site.config_sync_directory}</echo>
     </target>

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -269,7 +269,7 @@ Or, you can specify the export file directly:
             <option name="site-name">${projectname}</option>
             <option name="account-name">${drupal.site.admin_user}</option>
             <option name="account-pass">admin</option>
-            <param>${drupal.site.profile}</param>
+            <param>standard</param>
         </drush>
 
         <drush command="pm-enable" assume="yes">
@@ -285,7 +285,10 @@ Or, you can specify the export file directly:
         <!-- Whitespace is intentional. -->
         <echo>
 
-             Drupal has been installed with the install profile "${drupal.site.profile}". Future installs will be run using 'drush site:install --existing-config'.
+             Drupal has been installed with the install profile "standard". If you'd prefer a different profile, run the installer yourself:
+               drush site-install minimal
+
+             Future installs via 'phing install' will be run using 'drush site:install --existing-config'.
 
              Your config has been exported to ${drupal.root}/${drupal.site.config_sync_directory}</echo>
     </target>


### PR DESCRIPTION
Use `drush site-install --existing-config` instead of `drush site-install config_installer`. See #145 