### PR TITLE
Use extension list instead of ignore for phpcs

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -233,7 +233,7 @@ phpcs:
   ignore: "*.md"
   
   # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
-  extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml"
+  extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml,js"
 
 
 # Configuration for using PHP Mess Detector to check for general PHP best practices,

--- a/defaults.yml
+++ b/defaults.yml
@@ -228,9 +228,8 @@ phpcs:
   # Space-separated list of directories to review.
   directories: "${drupal.root}/modules/custom ${drupal.root}/themes/custom ${drupal.root}/profiles/custom"
 
-  # Comma-separated list of patterns for files and directories to exclude from the
-  # PHP_CodeSniffer review.
-  ignore: "*.md"
+  # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
+  extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml"
 
 
 # Configuration for using PHP Mess Detector to check for general PHP best practices,

--- a/defaults.yml
+++ b/defaults.yml
@@ -230,6 +230,10 @@ phpcs:
 
   # Comma-separated list of patterns for files and directories to exclude from the
   # PHP_CodeSniffer review.
+  #
+  # This is deprecated and will be removed in 3.0, and build.xml will need to be updated then to
+  # use the extensions option (below). This option should not be used with Coder >= 8.3.7, which only
+  # checks php, inc, css, and js by default.
   ignore: "*.md"
   
   # Comma-separated list of extensions to check in the PHP_CodeSniffer review.

--- a/defaults.yml
+++ b/defaults.yml
@@ -228,6 +228,10 @@ phpcs:
   # Space-separated list of directories to review.
   directories: "${drupal.root}/modules/custom ${drupal.root}/themes/custom ${drupal.root}/profiles/custom"
 
+  # Comma-separated list of patterns for files and directories to exclude from the
+  # PHP_CodeSniffer review.
+  ignore: "*.md"
+  
   # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
   extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml"
 

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -132,7 +132,7 @@
         </phplint>
 
         <!-- Run PHP Code Sniffer. -->
-        <property name="phpcs.command" value="vendor/bin/phpcs --standard=${phpcs.standard} --ignore=${phpcs.ignore} ${phpcs.directories}" />
+        <property name="phpcs.command" value="vendor/bin/phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}" />
         <echo msg="$> ${phpcs.command}" />
         <exec command="${phpcs.command}" logoutput="true" checkreturn="true" />
 


### PR DESCRIPTION
Due to https://www.drupal.org/project/coder/issues/3074176 ("Allow extensions to be overridden in contrib phpcs.xml file") included in Coder 8.37, the default list of extensions checked by `phpcs` has changed.

This removes the `ignore` configuration option and replaces it with `extensions` with a default that matches the original list in Coder.

**Note: This will require re-installing The Build or manually updating `build.xml` on projects.**

### Open questions

Should we add `js` to the list of extensions? The default behavior of Coder 8.3.7 checking JS files generated a lot of errors on one project where it was used, but it could be useful to have in the list.

Should we remove `ignore` from the defaults? This would cause projects that don't update their `build.xml` to start checking `.md` files, so it might be best to leave it in? Depending on the answer to the first question above, we could also add `*.js` to the list of ignored extensions to avoid checking files that weren't previously checked.