### PR TITLE
set drush default site uri

### DIFF
--- a/defaults/install/drush/drush.yml
+++ b/defaults/install/drush/drush.yml
@@ -16,3 +16,7 @@ sql:
       - 'search_*'
       - 'sessions'
       - 'watchdog'
+
+options:
+  # Set the default site URI.
+  uri: https://project.local

--- a/defaults/install/drush/drush.yml
+++ b/defaults/install/drush/drush.yml
@@ -17,6 +17,10 @@ sql:
       - 'sessions'
       - 'watchdog'
 
-options:
-  # Set the default site URI.
-  uri: https://project.local
+# Uncomment the following and change the URL to your site's preferred hostname.
+# This allows URLs to be generated that don't include `default` when no alias is
+# used.
+#
+# options:
+#   # Set the default site URI.
+#   uri: https://project.local


### PR DESCRIPTION
Adds an example to set the default site URI, so when `drush` is run without an alias, the correct URL is generated instead of `http://default/`.
