### PR TITLE
remove old config_directories variable from default settings.php

### DIFF
--- a/defaults/install_site/drupal/settings.php
+++ b/defaults/install_site/drupal/settings.php
@@ -15,7 +15,6 @@
 
 // This is the core set of defaults from default.settings.php. They will be overridden
 // as necessary by the includes below.
-$config_directories = [];
 $settings['hash_salt'] = '';
 $settings['update_free_access'] = FALSE;
 $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';


### PR DESCRIPTION
Since #140 was merged, we no longer need this variable assignment in the default `settings.php`.