### PR TITLE
install drupal-check on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,19 +46,6 @@ jobs:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
 
-      # Note: phing and drupal-check have mutually exclusive requirements.
-      # It'd be better to add drupal-check as a dependency of the drupal project
-      # rather than as part of the virtual environment, but this will have to do
-      # for now. Also note, drupal-check is added as part of the-vagrant so it
-      # is available to run within our VM.
-      - run:
-          name: Install drupal-check
-          command: |
-            curl -O -L https://github.com/mglaman/drupal-check/releases/download/1.0.9/drupal-check.phar
-            mkdir --parents ~/bin
-            mv drupal-check.phar ~/bin/drupal-check
-            chmod +x ~/bin/drupal-check
-
       # Composer package cache
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,11 @@ jobs:
       # is available to run within our VM.
       - run:
           name: Install drupal-check
-          command: composer global require mglaman/drupal-check
+          command: |
+            curl -O -L https://github.com/mglaman/drupal-check/releases/download/1.0.9/drupal-check.phar
+            mkdir --parents ~/bin
+            mv drupal-check.phar ~/bin/drupal-check
+            chmod +x ~/bin/drupal-check
 
       # Composer package cache
       - restore_cache:

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -43,6 +43,19 @@ jobs:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
 
+      # Note: phing and drupal-check have mutually exclusive requirements.
+      # It'd be better to add drupal-check as a dependency of the drupal project
+      # rather than as part of the virtual environment, but this will have to do
+      # for now. Also note, drupal-check is added as part of the-vagrant so it
+      # is available to run within our VM.
+      - run:
+          name: Install drupal-check
+          command: |
+            curl -O -L https://github.com/mglaman/drupal-check/releases/download/1.0.9/drupal-check.phar
+            mkdir --parents ~/bin
+            mv drupal-check.phar ~/bin/drupal-check
+            chmod +x ~/bin/drupal-check
+
       # Composer package cache
       - restore_cache:
           keys:

--- a/defaults/install/the-build/build.circleci.yml
+++ b/defaults/install/the-build/build.circleci.yml
@@ -15,4 +15,4 @@ behat:
   args: "--profile=circleci --suite=default --strict --format=junit --out=/tmp/artifacts --tags=~@skipci"
 
 drupal-check:
-  bin: "/home/circleci/.composer/vendor/bin/drupal-check"
+  bin: "/home/circleci/bin/drupal-check"


### PR DESCRIPTION
- Removes the `drupal-check` installation step from the CircleCI config that tests The Build itself.
- Adds a step in the CircleCI config template to install `drupal-check`.
- Matches the installation method for `drupal-check` with The Vagrant. Installing via Composer can lead to issues as dependencies change. For example:
```
     [exec]  ------ --------------------------------------------------------------
     [exec]          Internal error: Call to undefined method
     [exec]          PhpParser\Comment\Doc::getEndLine()
     [exec]          Run PHPStan with --debug option and post the stack trace to:
     [exec]          https://github.com/phpstan/phpstan/issues/new
     [exec]  ------ --------------------------------------------------------------
```

See https://github.com/palantirnet/the-build/pull/133/files#diff-1d37e48f9ceff6d8030570cd36286a61 and https://github.com/palantirnet/drupal-skeleton/pull/109