### PR TITLE
Update installer so composer will run when selecting platformsh

### DIFF
--- a/targets/install.xml
+++ b/targets/install.xml
@@ -9,7 +9,7 @@
 
 <project name="install" default="install">
 
-    <!-- This is required to set ${composer.composer} for installing for Platform.sh
+    <!-- This is required to set ${composer.composer} for installing for Platform.sh -->
     <import file="the-build.xml" />
 
     <property name="build.dir" value="${application.startdir}" />

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -9,6 +9,8 @@
 
 <project name="install" default="install">
 
+    <!-- This is required to set ${composer.composer} for installing for Platform.sh
+    <import file="the-build.xml" />
 
     <property name="build.dir" value="${application.startdir}" />
     <property name="build.env" value="default" />
@@ -268,6 +270,7 @@
 
             <case value="platformsh">
                 <composer command="require" composer="${composer.composer}">
+                    <arg line="--working-dir ${application.startdir}" />
                     <arg value="platformsh/config-reader:^2.1" />
                 </composer>
                 <httpget url="https://raw.githubusercontent.com/platformsh/template-drupal8/master/web/sites/default/settings.platformsh.php" dir="${build.dir}/${drupal.root}/sites/${drupal.site.dir}" />


### PR DESCRIPTION
When installing the-build for a project on Platform.sh, the installation fails while attempting to install `config-reader` with Composer because `${composer.composer} has not been set. Also, Composer was not being run in the project directory.

- Imports `the-build.xml` in order for the Composer location to be set.
- Adds `--working-dir` argument when running composer, so the correct `composer.json` will be updated.

## Testing

- Create a new project or update an existing project to use this branch of `the-build`. For example, in `composer.json`:
```
"palantirnet/the-build": "dev-installer-platformsh-composer"
```
- `vendor/bin/the-build-installer`
- Select `platformsh` as the hosting platform.
- Verify the `config-reader` dependency is successfully added to `composer.json` and installed.

Note: You may need to run `sudo composer self-update` inside the VM if you receive "unable to allocate memory" errors.