### PR TITLE
Drupal 9 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       # Create a new project using the drupal-skeleton project
       - run:
           name: Create a new Drupal project
-          command: composer create-project palantirnet/drupal-skeleton example dev-drupal8 --no-interaction
+          command: composer create-project palantirnet/drupal-skeleton example dev-drupal9 --no-interaction
           working_directory: ~/
 
       # Use this copy of the-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     working_directory: ~/example
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: circleci/php:7.3-node-browsers
       - image: circleci/mysql:5.7-ram
         command: --max_allowed_packet=16M
         environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## UNRELEASED
+
+### Changed
+
+* `phing install` now uses `drush site-install --existing-config` instead of the [config_installer profile](https://www.drupal.org/project/config_installer) (#145)
+
+### Deprecated
+
+* The `drupal.site.profile` property is no longer used by the default `install` target in `build.xml`. It will be removed in the 3.0 release. (#145)
+
 ## 2.3.1
 
 ### Changed

--- a/defaults.yml
+++ b/defaults.yml
@@ -95,6 +95,11 @@ drupal:
       hash_salt: temporary
 
       # Drupal install profile to use for the drupal-install target.
+      #
+      # DEPRECATED - to be removed in 3.0
+      # This property was used in the 'install' target in the default build.xml, until
+      # we switched from the config_installer profile to using
+      # 'drush site-install --existing-config`.
       profile: config_installer
 
       # Drupal admin username, if you feel inclined to change it.

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -74,14 +74,6 @@
             <option name="account-pass">admin</option>
             <option name="existing-config" />
         </drush>
-
-        <drush command="pm-enable" assume="yes">
-            <param>the_build_utility</param>
-        </drush>
-
-        <drush command="pm-uninstall" assume="yes">
-            <param>the_build_utility</param>
-        </drush>
     </target>
 
 

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -74,6 +74,14 @@
             <option name="account-pass">admin</option>
             <option name="existing-config" />
         </drush>
+
+        <drush command="pm-enable" assume="yes">
+            <param>the_build_utility</param>
+        </drush>
+
+        <drush command="pm-uninstall" assume="yes">
+            <param>the_build_utility</param>
+        </drush>
     </target>
 
 

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -72,7 +72,7 @@
             <option name="site-name">${projectname}</option>
             <option name="account-name">${drupal.site.admin_user}</option>
             <option name="account-pass">admin</option>
-            <param>${drupal.site.profile}</param>
+            <option name="existing-config" />
         </drush>
     </target>
 

--- a/defaults/standard/modules/the_build_utility/the_build_utility.info.yml
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.info.yml
@@ -6,6 +6,8 @@ core_version_requirement: ^8 || ^9
 hide: true
 
 dependencies:
+  # Core modules
+  - drupal:shortcut
   # Contrib modules
   - config_split:config_split
   - devel:devel

--- a/defaults/standard/modules/the_build_utility/the_build_utility.info.yml
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.info.yml
@@ -6,8 +6,6 @@ core_version_requirement: ^8 || ^9
 hide: true
 
 dependencies:
-  # Core modules
-  - drupal:shortcut
   # Contrib modules
   - config_split:config_split
   - devel:devel

--- a/defaults/standard/modules/the_build_utility/the_build_utility.info.yml
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.info.yml
@@ -2,6 +2,7 @@ name: the-build utility module
 description: 'Base settings from palantirnet/the-build.'
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9
 hide: true
 
 dependencies:

--- a/defaults/standard/modules/the_build_utility/the_build_utility.install
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.install
@@ -17,36 +17,6 @@ use Drupal\shortcut\Entity\Shortcut;
  * @see system_install()
  */
 function the_build_utility_install() {
-  // hook_install() from standard profile.
-
-  // Assign user 1 the "administrator" role.
-  $user = User::load(1);
-  $user->roles[] = 'administrator';
-  $user->save();
-
-  // We install some menu links, so we have to rebuild the router, to ensure the
-  // menu links are valid.
-  \Drupal::service('router.builder')->rebuildIfNeeded();
-
-  // Populate the default shortcut set.
-  $shortcut = Shortcut::create([
-    'shortcut_set' => 'default',
-    'title' => t('Add content'),
-    'weight' => -20,
-    'link' => ['uri' => 'internal:/node/add'],
-  ]);
-  $shortcut->save();
-
-  $shortcut = Shortcut::create([
-    'shortcut_set' => 'default',
-    'title' => t('All content'),
-    'weight' => -19,
-    'link' => ['uri' => 'internal:/admin/content'],
-  ]);
-  $shortcut->save();
-
-  // Customizations from this module.
-
   // Allow visitor account creation with administrative approval.
   $user_settings = \Drupal::configFactory()->getEditable('user.settings');
   $user_settings->set('register', 'admin_only')->save(TRUE);

--- a/defaults/standard/modules/the_build_utility/the_build_utility.install
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.install
@@ -55,7 +55,7 @@ function the_build_utility_install() {
   $shortcut = Shortcut::create([
     'shortcut_set' => 'default',
     'title' => t('Manage Taxonomy'),
-    'weight' => -20,
+    'weight' => -18,
     'link' => ['uri' => 'internal:/admin/structure/taxonomy'],
   ]);
   $shortcut->save();
@@ -63,7 +63,7 @@ function the_build_utility_install() {
   $shortcut = Shortcut::create([
     'shortcut_set' => 'default',
     'title' => t('Manage Menus'),
-    'weight' => -19,
+    'weight' => -17,
     'link' => ['uri' => 'internal:/admin/structure/menu'],
   ]);
   $shortcut->save();
@@ -71,7 +71,7 @@ function the_build_utility_install() {
   $shortcut = Shortcut::create([
     'shortcut_set' => 'default',
     'title' => t('Status Report'),
-    'weight' => -18,
+    'weight' => -16,
     'link' => ['uri' => 'internal:/admin/reports/status'],
   ]);
   $shortcut->save();

--- a/defaults/standard/modules/the_build_utility/the_build_utility.install
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.install
@@ -62,7 +62,6 @@ function the_build_utility_install() {
   // Begin Comment module.
   // Remove the comment fields.
   $fields = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['type' => 'comment']);
-  $fields = entity_load_multiple_by_properties('field_storage_config', ['type' => 'comment']);
   foreach ($fields as $field) {
     $field->delete();
   }

--- a/defaults/standard/modules/the_build_utility/the_build_utility.install
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.install
@@ -17,6 +17,36 @@ use Drupal\shortcut\Entity\Shortcut;
  * @see system_install()
  */
 function the_build_utility_install() {
+  // hook_install() from standard profile.
+
+  // Assign user 1 the "administrator" role.
+  $user = User::load(1);
+  $user->roles[] = 'administrator';
+  $user->save();
+
+  // We install some menu links, so we have to rebuild the router, to ensure the
+  // menu links are valid.
+  \Drupal::service('router.builder')->rebuildIfNeeded();
+
+  // Populate the default shortcut set.
+  $shortcut = Shortcut::create([
+    'shortcut_set' => 'default',
+    'title' => t('Add content'),
+    'weight' => -20,
+    'link' => ['uri' => 'internal:/node/add'],
+  ]);
+  $shortcut->save();
+
+  $shortcut = Shortcut::create([
+    'shortcut_set' => 'default',
+    'title' => t('All content'),
+    'weight' => -19,
+    'link' => ['uri' => 'internal:/admin/content'],
+  ]);
+  $shortcut->save();
+
+  // Customizations from this module.
+
   // Allow visitor account creation with administrative approval.
   $user_settings = \Drupal::configFactory()->getEditable('user.settings');
   $user_settings->set('register', 'admin_only')->save(TRUE);

--- a/defaults/standard/modules/the_build_utility/the_build_utility.install
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.install
@@ -19,7 +19,7 @@ use Drupal\shortcut\Entity\Shortcut;
 function the_build_utility_install() {
   // Allow visitor account creation with administrative approval.
   $user_settings = \Drupal::configFactory()->getEditable('user.settings');
-  $user_settings->set('register', USER_REGISTER_ADMINISTRATORS_ONLY)->save(TRUE);
+  $user_settings->set('register', 'admin_only')->save(TRUE);
 
   // Populate the default shortcut set.
   $shortcut = Shortcut::create([

--- a/defaults/standard/modules/the_build_utility/the_build_utility.install
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.install
@@ -61,6 +61,7 @@ function the_build_utility_install() {
 
   // Begin Comment module.
   // Remove the comment fields.
+  $fields = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['type' => 'comment']);
   $fields = entity_load_multiple_by_properties('field_storage_config', ['type' => 'comment']);
   foreach ($fields as $field) {
     $field->delete();

--- a/defaults/standard/modules/the_build_utility/the_build_utility.install
+++ b/defaults/standard/modules/the_build_utility/the_build_utility.install
@@ -61,7 +61,7 @@ function the_build_utility_install() {
 
   // Begin Comment module.
   // Remove the comment fields.
-  $fields = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['type' => 'comment']);
+  $fields = \Drupal::entityTypeManager()->getStorage('field_storage_config')->loadByProperties(['type' => 'comment']);
   foreach ($fields as $field) {
     $field->delete();
   }

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -269,7 +269,7 @@ Or, you can specify the export file directly:
             <option name="site-name">${projectname}</option>
             <option name="account-name">${drupal.site.admin_user}</option>
             <option name="account-pass">admin</option>
-            <param>newstandard</param>
+            <param>standard</param>
         </drush>
 
         <drush command="pm-enable" assume="yes">

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -269,28 +269,11 @@ Or, you can specify the export file directly:
             <option name="site-name">${projectname}</option>
             <option name="account-name">${drupal.site.admin_user}</option>
             <option name="account-pass">admin</option>
-            <param>standard</param>
+            <param>minimal</param>
         </drush>
 
         <drush command="pm-enable" assume="yes">
             <param>the_build_utility</param>
-        </drush>
-
-        <drush command="config-delete" assume="yes">
-            <param>core.extension</param>
-            <param>module.standard</param>
-        </drush>
-
-        <drush command="config-set" assume="yes">
-            <param>core.extension</param>
-            <param>module.config_installer</param>
-            <param>1000</param>
-        </drush>
-
-        <drush command="config-set" assume="yes">
-            <param>core.extension</param>
-            <param>profile</param>
-            <param>config_installer</param>
         </drush>
 
         <drush command="pm-uninstall" assume="yes">

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -302,7 +302,10 @@ Or, you can specify the export file directly:
         <!-- Whitespace is intentional. -->
         <echo>
 
-             Drupal has been installed with the install profile "standard". Future installs will be run using config_installer.
+             Drupal has been installed with the install profile "standard". If you'd prefer a different profile, run the installer yourself:
+               drush site-install minimal
+
+             Future installs via 'phing install' will be run using 'drush site:install --existing-config'.
 
              Your config has been exported to ${drupal.root}/${drupal.site.config_sync_directory}</echo>
     </target>

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -260,7 +260,7 @@ Or, you can specify the export file directly:
         <composer command="require" composer="${composer.composer}">
             <arg value="drupal/admin_toolbar" />
             <arg value="drupal/config_split" />
-            <arg value="drupal/devel" />
+            <arg value="drupal/devel:^3.0" />
             <arg value="drupal/workbench" />
             <arg value="drupal/workbench_tabs" />
         </composer>

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -269,7 +269,7 @@ Or, you can specify the export file directly:
             <option name="site-name">${projectname}</option>
             <option name="account-name">${drupal.site.admin_user}</option>
             <option name="account-pass">admin</option>
-            <param>minimal</param>
+            <param>newstandard</param>
         </drush>
 
         <drush command="pm-enable" assume="yes">

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -276,6 +276,23 @@ Or, you can specify the export file directly:
             <param>the_build_utility</param>
         </drush>
 
+        <drush command="config-delete" assume="yes">
+            <param>core.extension</param>
+            <param>module.standard</param>
+        </drush>
+
+        <drush command="config-set" assume="yes">
+            <param>core.extension</param>
+            <param>module.minimal</param>
+            <param>1000</param>
+        </drush>
+
+        <drush command="config-set" assume="yes">
+            <param>core.extension</param>
+            <param>profile</param>
+            <param>minimal</param>
+        </drush>
+
         <drush command="pm-uninstall" assume="yes">
             <param>the_build_utility</param>
         </drush>

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -276,22 +276,9 @@ Or, you can specify the export file directly:
             <param>the_build_utility</param>
         </drush>
 
-        <drush command="config-delete" assume="yes">
-            <param>core.extension</param>
-            <param>module.standard</param>
-        </drush>
-
-        <drush command="config-set" assume="yes">
-            <param>core.extension</param>
-            <param>module.minimal</param>
-            <param>1000</param>
-        </drush>
-
-        <drush command="config-set" assume="yes">
-            <param>core.extension</param>
-            <param>profile</param>
-            <param>minimal</param>
-        </drush>
+        <phingcall target="drupal-change-profile">
+            <property name="new_profile" value="minimal" />
+        </phingcall>
 
         <drush command="pm-uninstall" assume="yes">
             <param>the_build_utility</param>
@@ -308,6 +295,49 @@ Or, you can specify the export file directly:
              Future installs via 'phing install' will be run using 'drush site:install --existing-config'.
 
              Your config has been exported to ${drupal.root}/${drupal.site.config_sync_directory}</echo>
+    </target>
+
+
+    <target name="drupal-change-profile" description="Change the install profile on an existing Drupal site.">
+        <fail unless="new_profile" />
+
+        <!-- Get the name of the current profile. -->
+        <drush command="config-get" returnProperty="current_profile">
+            <param>core.extension</param>
+            <param>profile</param>
+            <option name="format">csv</option>
+        </drush>
+
+        <!-- If the current profile is enabled in the core extensions list, disable it. -->
+        <drush command="config-get" returnProperty="current_profile_weight">
+            <param>core.extension</param>
+            <param>module.${current_profile}</param>
+            <option name="format">csv</option>
+        </drush>
+
+        <if>
+            <not><equals arg1="${current_profile_weight}" arg2="" /></not>
+            <then>
+                <drush command="config-delete" assume="yes">
+                    <param>core.extension</param>
+                    <param>module.${current_profile}</param>
+                </drush>
+            </then>
+        </if>
+
+        <!-- Enable the new profile. -->
+        <drush command="config-set" assume="yes">
+            <param>core.extension</param>
+            <param>module.${new_profile}</param>
+            <param>1000</param>
+        </drush>
+
+        <!-- Update the profile setting itself. -->
+        <drush command="config-set" assume="yes">
+            <param>core.extension</param>
+            <param>profile</param>
+            <param>${new_profile}</param>
+        </drush>
     </target>
 
 


### PR DESCRIPTION
- Updates the `drupal-first-install` target to use Devel 3.0+ for compatibility with D9.
- Updates `the_build_utility` to be compatible with D9.
- Switches to the "minimal" profile, because Config Installer is no longer available, and the "standard" profile has a `hook_install()` disqualifying it from `drush site-install --existing-config`. See https://github.com/palantirnet/the-build/pull/147, https://github.com/palantirnet/the-build/pull/145, and https://www.drupal.org/project/drupal/issues/2982052

## Testing

Follow the instructions on https://github.com/palantirnet/drupal-skeleton/pull/111 to setup a new example project using this branch of the-build.

Note: After review and testing is complete, change the CircleCI config to use the `develop` branch of the Drupal Skeleton. See https://github.com/palantirnet/the-build/blob/744c327e9364e12d09c15d880e64a8756e06fbed/.circleci/config.yml#L76