### PR TITLE
Add CircleCI deploy job examples

### DIFF
--- a/defaults/install/.circleci/deploy-acquia-example
+++ b/defaults/install/.circleci/deploy-acquia-example
@@ -28,9 +28,9 @@
       - ACQUIA_PUBKEY: "svn-23450.prod.hosting.acquia.com,54.245.120.237 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDit0Rj8j59i9Gj2vOg2TXjIbPswIc27PwncapyBLi9R3FtECXq+md1BfykBJjME83m78CtqkTlWwNZu+LyhF+IYlshKo82JXQzV4kWwi5L9H7KpdyFDMDLVCNVYmU4EQY9ngRq1cwbMBYsfWxv4sSlbsvZv2C8U7luNoc4SiBY4sGpgiMJLFOHWRw6YvhOamLTKfxSoJUT8uRbfkamxas1EK21XjvrdUSN0Bf5LmTdvs/9iIaUH4AlYr0SW0tc2IbIuoFVxuvSzZj2GJjmtCcW1poDMQLTGq+EuO4Mk1WyoUSJC9L8CFonKH7++EPHopvIbPMinO4r2zLEot3lL5TH"
 
     steps:
-      - add_ssh_keys
       - attach_workspace:
           at: ..
+      - add_ssh_keys
       - run:
           name: Install packages
           command: sudo apt-get install -y libpng-dev
@@ -58,6 +58,7 @@
       - run:
           name: Add public keys to known hosts file.
           command: |
+            mkdir -p ~/.ssh
             echo $GITHUB_PUBKEY  >> ~/.ssh/known_hosts
             echo $ACQUIA_PUBKEY  >> ~/.ssh/known_hosts
       - run:

--- a/defaults/install/.circleci/deploy-acquia-example
+++ b/defaults/install/.circleci/deploy-acquia-example
@@ -1,0 +1,68 @@
+# Example snippet for deploy job in config.yml. Add this code to deploy to Acquia. Update ACQUIA_PUBKEY
+# with the entry from your known_hosts file for the Git remote host.
+#
+# You will also need to add a step to the build job to persist to workspace:
+#
+#      - persist_to_workspace:
+#          root: ..
+#          paths:
+#            - project
+#
+# And, finally, add the new job to the workflow section:
+#
+#      - deploy:
+#          requires:
+#            - build
+#          filters:
+#            branches:
+#              only:
+#                - develop
+
+  deploy:
+    working_directory: ~/project
+    docker:
+      - image: circleci/php:7.2-node-browsers
+    environment:
+      - NODE_VERSION: 8
+      - GITHUB_PUBKEY: "github.com,192.30.253.113 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+      - ACQUIA_PUBKEY: "svn-23450.prod.hosting.acquia.com,54.245.120.237 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDit0Rj8j59i9Gj2vOg2TXjIbPswIc27PwncapyBLi9R3FtECXq+md1BfykBJjME83m78CtqkTlWwNZu+LyhF+IYlshKo82JXQzV4kWwi5L9H7KpdyFDMDLVCNVYmU4EQY9ngRq1cwbMBYsfWxv4sSlbsvZv2C8U7luNoc4SiBY4sGpgiMJLFOHWRw6YvhOamLTKfxSoJUT8uRbfkamxas1EK21XjvrdUSN0Bf5LmTdvs/9iIaUH4AlYr0SW0tc2IbIuoFVxuvSzZj2GJjmtCcW1poDMQLTGq+EuO4Mk1WyoUSJC9L8CFonKH7++EPHopvIbPMinO4r2zLEot3lL5TH"
+
+    steps:
+      - add_ssh_keys
+      - attach_workspace:
+          at: ..
+      - run:
+          name: Install packages
+          command: sudo apt-get install -y libpng-dev
+
+      - run:
+          name: Install nvm
+          command: |
+            set +e
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+            touch $BASH_ENV
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+      - run:
+          name: Install PHP extensions
+          command: sudo docker-php-ext-install gd
+      - run:
+          name: Configure PHP
+          command: |
+            echo "memory_limit=-1" | sudo tee -a "/usr/local/etc/php/php.ini"
+      - run:
+          name: Configure Git
+          command: |
+            git config --global user.email "circle@palantir.net"
+            git config --global user.name "Circle Deploy"
+      - run:
+          name: Add public keys to known hosts file.
+          command: |
+            echo $GITHUB_PUBKEY  >> ~/.ssh/known_hosts
+            echo $ACQUIA_PUBKEY  >> ~/.ssh/known_hosts
+      - run:
+          name: Make sites/default writable for artifact build
+          command: chmod u+w docroot/sites/default
+      - run:
+          name: Build and deploy an artifact
+          command: vendor/bin/phing artifact -Dpush=y

--- a/defaults/install/.circleci/deploy-pantheon.example
+++ b/defaults/install/.circleci/deploy-pantheon.example
@@ -1,0 +1,71 @@
+# Example snippet for deploy job in config.yml. Add this code to deploy to Pantheon. Update PANTHEON_PUBKEY
+# with the entry from your known_hosts file for the code server.
+#
+# You will also need to add a step to the build job to persist to workspace:
+#
+#      - persist_to_workspace:
+#          root: ..
+#          paths:
+#            - project
+#
+# And, finally, add the new job to the workflow section:
+#
+#      - deploy:
+#          requires:
+#            - build
+#          filters:
+#            branches:
+#              only:
+#                - develop
+#                - master
+
+  deploy:
+    working_directory: ~/project
+    docker:
+      - image: circleci/php:7.2-node-browsers
+    environment:
+      - GITHUB_PUBKEY: "github.com,192.30.253.113 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+      - PANTHEON_PUBKEY: "[codeserver.dev.56f20816-b4b7-4517-a90f-667b4785708d.drush.in]:2222,[35.193.151.123]:2222 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSY3gnr0DrbqJJSnEFy6jazDmAdBm4Zs/EkWIQa7x31qgSYyYJMz5V+pk62lBf2BN42VtubwO83vW9G+yG2K1RGOvZJaK5GBvBb/Ws2ZPcp/4sNHpPzkdd75e5/Pk8AWA59XUbJcBWmrDrHMbWV1j2zqPPikxbqGeTTjSx4QR18LIRei5OwT6VQnaVnJqPAqFZ+oCbpr0DL96foL3UEY8EWT/6GH2cANEGZO4ppbhdDw4uG6TaI7S0lxWMQEVy+iwjCNH/nanjd73cwoYd90E0OVdgNDr3hVbIuE6sUW6UwlaAwuyOM/xJYPg1y0rF66958pyVJlZ9KD5A0kY3bHg7"
+      - NODE_VERSION: 8
+
+    steps:
+      - attach_workspace:
+          at: ..
+      - add_ssh_keys
+      - run:
+          name: Install packages
+          command: sudo apt-get install -y libpng-dev default-mysql-client libmcrypt-dev
+
+      - run:
+          name: Install nvm
+          command: |
+            set +e
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
+            touch $BASH_ENV
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+      - run:
+          name: Install PHP extensions
+          command: sudo docker-php-ext-install pdo_mysql gd
+      - run:
+          name: Configure PHP
+          command: |
+            echo "sendmail_path=/bin/true" | sudo tee -a "/usr/local/etc/php/php.ini"
+            echo "memory_limit=-1" | sudo tee -a "/usr/local/etc/php/php.ini"
+      - run:
+          name: Configure Git
+          command: |
+            git config --global user.email "circle@palantir.net"
+            git config --global user.name "Circle Deploy"
+      - run:
+          name: Add public keys to known hosts file.
+          command: |
+            mkdir -p ~/.ssh
+            echo $PANTHEON_PUBKEY >> ~/.ssh/known_hosts
+            echo $GITHUB_PUBKEY >> ~/.ssh/known_hosts
+      - run:
+          name: Make sites/default writable for artifact build
+          command: chmod u+w web/sites/default
+      - run:
+          name: Build and deploy an artifact
+          command: vendor/bin/phing artifact -Dpush=y -Dartifact.prefix=''

--- a/defaults/install/.circleci/deploy-pantheon.example
+++ b/defaults/install/.circleci/deploy-pantheon.example
@@ -24,9 +24,9 @@
     docker:
       - image: circleci/php:7.2-node-browsers
     environment:
+      - NODE_VERSION: 8
       - GITHUB_PUBKEY: "github.com,192.30.253.113 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
       - PANTHEON_PUBKEY: "[codeserver.dev.56f20816-b4b7-4517-a90f-667b4785708d.drush.in]:2222,[35.193.151.123]:2222 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSY3gnr0DrbqJJSnEFy6jazDmAdBm4Zs/EkWIQa7x31qgSYyYJMz5V+pk62lBf2BN42VtubwO83vW9G+yG2K1RGOvZJaK5GBvBb/Ws2ZPcp/4sNHpPzkdd75e5/Pk8AWA59XUbJcBWmrDrHMbWV1j2zqPPikxbqGeTTjSx4QR18LIRei5OwT6VQnaVnJqPAqFZ+oCbpr0DL96foL3UEY8EWT/6GH2cANEGZO4ppbhdDw4uG6TaI7S0lxWMQEVy+iwjCNH/nanjd73cwoYd90E0OVdgNDr3hVbIuE6sUW6UwlaAwuyOM/xJYPg1y0rF66958pyVJlZ9KD5A0kY3bHg7"
-      - NODE_VERSION: 8
 
     steps:
       - attach_workspace:
@@ -34,7 +34,7 @@
       - add_ssh_keys
       - run:
           name: Install packages
-          command: sudo apt-get install -y libpng-dev default-mysql-client libmcrypt-dev
+          command: sudo apt-get install -y libpng-dev
 
       - run:
           name: Install nvm
@@ -46,11 +46,10 @@
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
           name: Install PHP extensions
-          command: sudo docker-php-ext-install pdo_mysql gd
+          command: sudo docker-php-ext-install gd
       - run:
           name: Configure PHP
           command: |
-            echo "sendmail_path=/bin/true" | sudo tee -a "/usr/local/etc/php/php.ini"
             echo "memory_limit=-1" | sudo tee -a "/usr/local/etc/php/php.ini"
       - run:
           name: Configure Git
@@ -61,8 +60,8 @@
           name: Add public keys to known hosts file.
           command: |
             mkdir -p ~/.ssh
-            echo $PANTHEON_PUBKEY >> ~/.ssh/known_hosts
             echo $GITHUB_PUBKEY >> ~/.ssh/known_hosts
+            echo $PANTHEON_PUBKEY >> ~/.ssh/known_hosts
       - run:
           name: Make sites/default writable for artifact build
           command: chmod u+w web/sites/default


### PR DESCRIPTION
## Description

Adds two example files with a sample CircleCI deploy job for Acquia and Pantheon.

## Testing

Review the examples, and verify they look correct. They are based on https://github.com/palantirnet/honorhealth/blob/develop/.circleci/config.yml#L118-L164 and https://github.com/palantirnet/st-bernards/blob/develop/.circleci/config.yml#L121-L171