### PR TITLE
Remove drupal-check; we're now recommending upgrade_status instead.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,20 +46,6 @@ jobs:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
 
-      # Note: phing and drupal-check have mutually exclusive requirements.
-      # It'd be better to add drupal-check as a dependency of the drupal project
-      # rather than as part of the virtual environment, but this will have to do
-      # for now. Also note, drupal-check is added as part of the-vagrant so it
-      # is available to run within our VM.
-      # Note 2: drupal-check is pinned to a known stable version.
-      - run:
-          name: Install drupal-check
-          command: |
-            curl -O -L https://github.com/mglaman/drupal-check/releases/download/1.0.9/drupal-check.phar
-            mkdir --parents ~/bin
-            mv drupal-check.phar ~/bin/drupal-check
-            chmod +x ~/bin/drupal-check
-
       # Composer package cache
       - restore_cache:
           keys:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## UNRELEASED
+
+### Removed
+
+* `drupal-check` is no longer installed in the default CircleCI configuration, or used in the default code-review task. The [upgrade_status module](https://www.drupal.org/project/upgrade_status) is recommended instead.
+* The `drupal_check.bin` and `drupal_check.directories` properties will be removed in the 3.2 release.
+
+### Updating
+
+Recommended: remove `drupal-check` usage from your project:
+
+1. Remove the "Install drupal-check" step from your `.circleci/config.yml`
+2. Update your `build.xml` to:
+ 1. Edit the `code-review` target to remove the call to the `drupal-check` target.
+ 2. Remove the `drupal-check` target itself (starts with `<target name="drupal-check" ...`)
+
+You may also choose to continue using `drupal-check`. In this case, ensure that the `drupal_check.bin` and `drupal_check.directories` properties are fully declared in your build configuration at `.the-build/build.yml`.
+
 ## 3.0.0 - July 8, 2020
 
 This release introduces Drupal 9 compatibility by removing the dependency on the `drupal/config_installer` package. You will need to update existing sites manually (see the "Updating" section below).

--- a/defaults.yml
+++ b/defaults.yml
@@ -262,6 +262,7 @@ phpmd:
   # File extensions to review.
   suffixes: php,inc,module,theme,profile,install,test
 
+# DEPRECATED - to be removed in 3.2
 # Configuration for checking the site with the Drupal Checker code linter.
 #
 # @see https://github.com/mglaman/drupal-check

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -43,20 +43,6 @@ jobs:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
 
-      # Note: phing and drupal-check have mutually exclusive requirements.
-      # It'd be better to add drupal-check as a dependency of the drupal project
-      # rather than as part of the virtual environment, but this will have to do
-      # for now. Also note, drupal-check is added as part of the-vagrant so it
-      # is available to run within our VM.
-      # Note 2: drupal-check is pinned to a known stable version.
-      - run:
-          name: Install drupal-check
-          command: |
-            curl -O -L https://github.com/mglaman/drupal-check/releases/download/1.0.9/drupal-check.phar
-            mkdir --parents ~/bin
-            mv drupal-check.phar ~/bin/drupal-check
-            chmod +x ~/bin/drupal-check
-
       # Composer package cache
       - restore_cache:
           keys:

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -140,19 +140,6 @@
         <property name="phpmd.command" value="vendor/bin/phpmd ${phpmd.directories} ${phpmd.format} ${phpmd.rulesets} --suffixes=${phpmd.suffixes}" />
         <echo msg="$> ${phpmd.command}" />
         <exec command="${phpmd.command}" logoutput="true" checkreturn="true" />
-
-        <!-- Run Drupal Check. -->
-        <foreach list="${drupal-check.directories}" param="drupal-check.dir" target="drupal-check" />
-    </target>
-
-
-    <!-- Separated out so that we can use foreach. drupal-check only accepts a single directory argument. -->
-    <target name="drupal-check" hidden="true">
-        <fail unless="drupal-check.dir" />
-        <property name="drupal-check.bin" value="~/bin/drupal-check" />
-        <property name="drupal-check.command" value="${drupal-check.bin} ${drupal-check.dir}" />
-        <echo msg="$> ${drupal-check.command}" />
-        <exec command="${drupal-check.command}" logoutput="true" checkreturn="true" />
     </target>
 
 

--- a/defaults/install/the-build/build.circleci.yml
+++ b/defaults/install/the-build/build.circleci.yml
@@ -13,6 +13,3 @@ drupal:
 
 behat:
   args: "--profile=circleci --suite=default --strict --format=junit --out=/tmp/artifacts --tags=~@skipci"
-
-drupal-check:
-  bin: "/home/circleci/bin/drupal-check"

--- a/defaults/install/the-build/build.yml
+++ b/defaults/install/the-build/build.yml
@@ -51,13 +51,6 @@ drupal:
 behat:
   args: "--suite=default --strict"
 
-# Configuration for checking the site with the Drupal Checker code linter.
-drupal-check:
-  # Location of the drupal-check script. This script is currently installed globally
-  # on the-vagrant because of repository-level composer conflicts.
-  bin: "~/bin/drupal-check"
-
-
 # To build an artifact from your code, add the URL to your artifact git repository.
 # @see https://github.com/palantirnet/the-build/blob/release-2.0/defaults.yml
 #


### PR DESCRIPTION
My main concern about this change is that we're not replacing the functionality directly with upgrade_status, since it seems like that's the kind of thing you only install when you need it.

Thoughts?