### PR TITLE
Require the MySQL 5.6 driver for Acquia projects.

### DIFF
--- a/targets/install.xml
+++ b/targets/install.xml
@@ -262,6 +262,15 @@
         <switch value="${build.host}">
             <case value="acquia">
                 <copy file="${build.thebuild.dir}/defaults/install_site/drupal/settings.acquia.php" todir="${build.dir}/${drupal.root}/sites/${drupal.site.dir}" />
+                <!--
+                     As of July 2020, Acquia only provides MySQL 5.6. Drupal 9 requires an
+                     additional driver to use this older version.
+                     @see https://docs.acquia.com/acquia-cloud/create/install/drupal9/
+                     -->
+                <composer command="require" composer="${composer.composer}">
+                    <arg line="--working-dir ${application.startdir}" />
+                    <arg value="drupal/mysql56" />
+                </composer>
             </case>
 
             <case value="pantheon">


### PR DESCRIPTION
### Testing instructions

1. composer create-project with palantirnet/drupal-skeleton: `composer create-project palantirnet/drupal-skeleton test-the-build dev-develop --no-interaction`
2. cd into your new site: `cd test-the-build`
3. require this branch of the-build: `composer require --dev palantirnet/the-build:dev-mysql-5.6-driver-for-acquia`
4. run the installer for the-build: `vendor/bin/the-build-installer`
5. when it prompts you for the hosting platform, type `acquia`
6. (you'll see an error since the installer doesn't have access to mysql -- that's normal and expected!)
7. now look at your composer.json -- the `drupal/mysql56` package should be included

You would still need to enable the driver after installing drupal (`drush en mysql56`).
