### PR TITLE
Use `--ignore-platform-reqs` when building an artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - run:
           name: Install packages
-          command: sudo apt-get install -y libpng-dev default-mysql-client
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Install nvm
           command: |

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
       - run:
           name: Install packages
-          command: sudo apt-get install -y libpng-dev default-mysql-client
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Install nvm
           command: |

--- a/targets/artifact.xml
+++ b/targets/artifact.xml
@@ -232,7 +232,7 @@
     <target name="artifact-build" hidden="true">
         <echo>Installing composer dependencies in the artifact...</echo>
         <composer command="install" composer="${composer.composer}">
-            <arg line="--no-interaction --no-dev --working-dir=${artifact.directory}" />
+            <arg line="--no-interaction --no-dev --ignore-platform-reqs --working-dir=${artifact.directory}" />
         </composer>
 
         <echo>Deleting .git subdirectories added by Composer...</echo>


### PR DESCRIPTION
Allow the 'composer install' in the artifact build to run without all 'platform requirements' (e.g. not all PHP extensions required to run the codebase need to be present just to build the artifact)