### PR TITLE
fix composer cache path on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       # Composer package cache - update when the contents of the Composer cache directory
       # change. This cache is saved after installing Drupal, as the install process uses
       # composer to add a few modules.
-      - run: ls -1R ~/.composer/cache/ > /tmp/composer-cache.txt
+      - run: ls -1R ~/.cache/composer/ > /tmp/composer-cache.txt
       - save_cache:
           key: composer-v1-{{ checksum "/tmp/composer-cache.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       - save_cache:
           key: composer-v1-{{ checksum "/tmp/composer-cache.txt" }}
           paths:
-              - ~/.composer
+              - ~/.cache/composer
 
       # Add a multisite
       - run:

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -76,11 +76,11 @@ jobs:
 
       # Composer package cache - update when the contents of the Composer cache directory
       # change
-      - run: ls -1R ~/.composer/cache/ > /tmp/composer-cache.txt
+      - run: ls -1R ~/.cache/composer/ > /tmp/composer-cache.txt
       - save_cache:
           key: composer-v1-{{ checksum "/tmp/composer-cache.txt" }}
           paths:
-              - ~/.composer
+              - ~/.cache/composer
       # Source cache - update when branch changes
       - save_cache:
           key: source-v1-{{ .Branch }}


### PR DESCRIPTION
The Composer cache path seems to have changed on CircleCI, most likely due to the update to Composer 2.
```
#!/bin/bash -eo pipefail
ls -1R ~/.composer/cache/ > /tmp/composer-cache.txt
ls: cannot access '/home/circleci/.composer/cache/': No such file or directory
Exited with code exit status 2
CircleCI received exit code 2
```

Updating the Composer cache path in the CircleCI `config.yml` fixes the issue.