### PR TITLE
use --extensions instead of --ignore in "code-fix" target

### DIFF
--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -159,7 +159,7 @@
     <!-- Target: code-fix -->
     <target name="code-fix" description="Run the automated code fixer.">
         <!-- Run PHP Code Beautifier and Fixer. -->
-        <property name="phpcbf.command" value="vendor/bin/phpcbf --standard=${phpcs.standard} --ignore=${phpcs.ignore} ${phpcs.directories}" />
+        <property name="phpcbf.command" value="vendor/bin/phpcbf --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}" />
         <echo msg="$> ${phpcbf.command}" />
         <exec command="${phpcbf.command}" logoutput="true" checkreturn="false" />
     </target>


### PR DESCRIPTION
Makes sure `phing code-review` and `phing code-fix` are operating on the same set of files. We transitioned from using the `--ignore` argument to `--extensions` for code review, but the `code-fix` target was still using `--ignore`, which resulted in different files being scanned if `phpcs.extensions` was changed from the default.