### PR TITLE
WIP: Support running yarn outside ddev and other things inside

### DIFF
--- a/targets/styleguide.xml
+++ b/targets/styleguide.xml
@@ -91,6 +91,9 @@
         Target: styleguide-install
 
         Install the styleguide dependencies with composer and yarn.
+
+        To force a reinstall of the styleguide dependencies, use:
+          phing styleguide-install -Dyarn_install.reinstall=true
         -->
     <target name="styleguide-install" depends="styleguide-exists-or-else" hidden="true">
         <!-- Run composer install in the styleguide. -->
@@ -110,7 +113,12 @@
                 <available file="${styleguide.root.resolved}/yarn.lock" type="file" />
                 <or>
                   <not><available file="${styleguide.root.resolved}/node_modules/.yarn-integrity" type="file" /></not>
-                  <not><available file="${styleguide.root.resolved}/node_modules/node-sass/vendor/linux-x64-59/binding.node" type="file" /></not>
+                  <not>
+                      <isfileselected file="${styleguide.root}/node_modules/.yarn-integrity">
+                          <contains text="linux-x64" />
+                      </isfileselected>
+                  </not>
+                  <equals arg1="${yarn_install.reinstall}" arg2="TRUE" />
                 </or>
             </and>
             <then>

--- a/targets/styleguide.xml
+++ b/targets/styleguide.xml
@@ -127,5 +127,36 @@
         </if>
     </target>
 
+    <!--
+        Target: yarn-safe
+
+        Add this as a dependency of targets before running yarn commands (other than install).
+        -->
+    <target name="yarn-safe" hidden="true">
+      <fail unless="styleguide.root" message="Must be called with the 'styleguide.root' variable." />
+      <if>
+        <or>
+          <and>
+            <equals arg1="${env.IS_DDEV_PROJECT}" arg2="TRUE" />
+            <isfileselected file="${styleguide.root}/node_modules/.yarn-integrity">
+              <contains text="linux-x64" />
+            </isfileselected>
+          </and>
+          <and>
+            <not><isset property="env.IS_DDEV_PROJECT" /></not>
+            <isfileselected file="${styleguide.root}/node_modules/.yarn-integrity">
+              <contains text="darwin-x64" />
+            </isfileselected>
+          </and>
+          <isset property="env.CIRCLECI" />
+        </or>
+        <then>
+          <echo message="Safe to run yarn commands in ${styleguide.root}: yarn dependencies match this environment" />
+        </then>
+        <else>
+          <fail message="NOT safe to run yarn commands in ${styleguide.root}: yarn dependencies DO NOT MATCH this environment" />
+        </else>
+      </if>
+    </target>
 
 </project>


### PR DESCRIPTION
This especially matters when developers are working on both a js application and the Drupal application.

The `build` step assumes building everything, but that might not be possible depending on whether the environment where you're running `phing build` matches the environment where you ran `yarn install`. How do we smooth this path?

* Should we normalize running all phing commands outside of ddev?
* Should we add something to the phing-drush-task to detect if there's ddev and if so, run any drush commands inside of ddev if necessary?