### PR TITLE
Automatically run drush inside of ddev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "extra": {
         "patches": {
             "phing/phing": {
-                "Support relative symliks in Phing": "patches/phing-relative-symlinks.patch"
+                "Support relative symliks in Phing": "https://raw.githubusercontent.com/palantirnet/the-build/7cdc28b6019fb88a0604261366f9ea35f1e21d96/patches/phing-relative-symlinks.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,10 @@
         "bin/the-build-installer"
     ],
     "require": {
-        "palantirnet/phing-drush-task": "^1.1",
+        "cweagans/composer-patches": "^1.7",
         "drupal/coder": "^8.3.6",
         "drush/drush": "^9 || ^10",
+        "palantirnet/phing-drush-task": "^1.1",
         "pear/http_request2": "^2.3",
         "pear/versioncontrol_git": "@dev",
         "phing/phing": "^2.14",
@@ -27,5 +28,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "patches": {
+            "phing/phing": {
+                "Support relative symliks in Phing": "patches/phing-relative-symlinks.patch"
+            }
+        }
     }
 }

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -45,7 +45,7 @@
 
         <!-- Include styleguide resources in the theme. This approach will symlink
              resources in development environments, and copy them for artifact builds. -->
-        <!-- <includeresource source="styleguide/source/assets/css" dest="${drupal.root}/themes/custom/example_theme/css" /> -->
+        <!-- <includeresource relative="true" source="${build.dir}/styleguide/source/assets/css" dest="${build.dir}/${drupal.root}/themes/custom/example_theme/css" /> -->
     </target>
 
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,9 @@
+### phing-relative-symlinks.patch
+
+Source: [https://github.com/phingofficial/phing/pull/695](https://github.com/phingofficial/phing/pull/695)
+
+This patch updates Phing's SymlinkTask to allow creating relative symlinks, using the syntax:
+
+```
+<symlink link="path/to/destination" target="path/to/target" relative="true" />
+```

--- a/patches/phing-relative-symlinks.patch
+++ b/patches/phing-relative-symlinks.patch
@@ -1,0 +1,76 @@
+diff --git a/classes/phing/tasks/ext/SymlinkTask.php b/classes/phing/tasks/ext/SymlinkTask.php
+index f132b4f747..87844a0d09 100644
+--- a/classes/phing/tasks/ext/SymlinkTask.php
++++ b/classes/phing/tasks/ext/SymlinkTask.php
+@@ -206,6 +206,46 @@ public function isRelative()
+         return $this->relative;
+     }
+ 
++    /**
++     * Given an existing path, convert it to a path relative to a given starting path.
++     *
++     * @param string $endPath   Absolute path of target
++     * @param string $startPath Absolute path where traversal begins
++     *
++     * @return string Path of target relative to starting path
++     */
++    public function makePathRelative($endPath, $startPath)
++    {
++        // Normalize separators on Windows
++        if ('\\' === DIRECTORY_SEPARATOR) {
++            $endPath = str_replace('\\', '/', $endPath);
++            $startPath = str_replace('\\', '/', $startPath);
++        }
++
++        // Split the paths into arrays
++        $startPathArr = explode('/', trim($startPath, '/'));
++        $endPathArr = explode('/', trim($endPath, '/'));
++
++        // Find for which directory the common path stops
++        $index = 0;
++        while (isset($startPathArr[$index]) && isset($endPathArr[$index]) && $startPathArr[$index] === $endPathArr[$index]) {
++            ++$index;
++        }
++
++        // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
++        $depth = count($startPathArr) - $index;
++
++        // Repeated "../" for each level need to reach the common path
++        $traverser = str_repeat('../', $depth);
++
++        $endPathRemainder = implode('/', array_slice($endPathArr, $index));
++
++        // Construct $endPath from traversing to the common path, then to the remaining $endPath
++        $relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
++
++        return '' === $relativePath ? './' : $relativePath;
++    }
++
+     /**
+      * Generates an array of directories / files to be linked
+      * If _filesets is empty, returns getTarget()
+@@ -235,11 +275,7 @@ protected function getMap()
+                 throw new BuildException('Link must be an existing directory when using fileset');
+             }
+ 
+-            if ($this->isRelative()) {
+-                $fromDir = $fs->getDir($this->getProject())->getPath();
+-            } else {
+-                $fromDir = $fs->getDir($this->getProject())->getAbsolutePath();
+-            }
++            $fromDir = $fs->getDir($this->getProject())->getAbsolutePath();
+ 
+             if (!is_dir($fromDir)) {
+                 $this->log('Directory doesn\'t exist: ' . $fromDir, Project::MSG_WARN);
+@@ -300,6 +336,11 @@ protected function symlink($target, $link)
+     {
+         $fs = FileSystem::getFileSystem();
+ 
++        if ($this->isRelative()) {
++           $link =(new PhingFile($link))->getAbsolutePath();
++           $target = rtrim($this->makePathRelative($target, dirname($link)), '/');
++        }
++
+         if (is_link($link) && @readlink($link) == $target) {
+             $this->log('Link exists: ' . $link, Project::MSG_INFO);
+ 

--- a/src/TheBuild/IncludeResourceTask.php
+++ b/src/TheBuild/IncludeResourceTask.php
@@ -32,6 +32,12 @@ class IncludeResourceTask extends \Task {
    */
   protected $dest = NULL;
 
+  /**
+   * Whether to create relative symlinks
+   *
+   * @var boolean
+   */
+  private $relative = false;
 
   /**
    * Init tasks.
@@ -43,6 +49,10 @@ class IncludeResourceTask extends \Task {
     $mode = $this->getProject()->getProperty('includeresource.mode');
     if (!is_null($mode)) {
       $this->setMode($mode);
+    }
+    $relative = $this->getProject()->getProperty('includeresource.relative');
+    if (!is_null($relative)) {
+      $this->setRelative($relative);
     }
   }
 
@@ -70,7 +80,11 @@ class IncludeResourceTask extends \Task {
     }
     else {
       $this->log(sprintf("Linking '%s' to '%s'", $this->source->getPath(), $this->dest->getPath()));
-      FileSystem::getFileSystem()->symlink($this->source->getPath(), $this->dest->getPath());
+      $symlink_task = $this->project->createTask("symlink");
+      $symlink_task->setTarget($this->source->getPath());
+      $symlink_task->setLink($this->dest->getPath());
+      $symlink_task->setRelative($this->relative);
+      $symlink_task->main();
     }
   }
 
@@ -120,6 +134,14 @@ class IncludeResourceTask extends \Task {
    */
   public function setDest(PhingFile $dest) {
     $this->dest = $dest;
+  }
+
+  /**
+   * @param boolean $relative
+   */
+  public function setRelative($relative)
+  {
+      $this->relative = $relative;
   }
 
 }

--- a/src/TheBuild/IncludeResourceTask.php
+++ b/src/TheBuild/IncludeResourceTask.php
@@ -37,7 +37,7 @@ class IncludeResourceTask extends \Task {
    *
    * @var boolean
    */
-  private $relative = false;
+  private $relative = true;
 
   /**
    * Init tasks.

--- a/src/TheBuild/IncludeResourceTask.php
+++ b/src/TheBuild/IncludeResourceTask.php
@@ -37,7 +37,7 @@ class IncludeResourceTask extends \Task {
    *
    * @var boolean
    */
-  private $relative = true;
+  protected $relative = true;
 
   /**
    * Init tasks.

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -179,23 +179,34 @@ Or, you can specify the export file directly:
 
     <!-- Target: drupal-has-database-connection
 
-         Check for a Drupal database connection.
+         Check for a Drupal database connection. If the database doesn't exist and we have
+         the permissions, the database will be created.
          -->
     <target name="drupal-has-database-connection" depends="set-site" hidden="true">
-        <drush command="status" returnProperty="drupal_has_database_connection">
-            <option name="fields" value="db-status" />
-            <option name="format" value="string" />
-        </drush>
-
-        <if>
-            <equals arg1="${drupal_has_database_connection}" arg2="Connected" />
-            <then>
+        <trycatch>
+            <try>
+                <drush command="sql-query">
+                    <param>SELECT 1</param>
+                </drush>
                 <echo msg="Drupal database connection available." />
-            </then>
-            <else>
-                <fail msg="Drupal database connection not available." />
-            </else>
-        </if>
+            </try>
+            <catch>
+                <trycatch>
+                    <try>
+                        <!-- If there's a database and it is accessible, this code will
+                             not be run. This code can help with setting up new
+                             multisites, since they will use new databases that may or may
+                             not exist yet.
+                             -->
+                        <drush command="sql-create" assume="yes" />
+                        <echo msg="Drupal database connection available." />
+                    </try>
+                    <catch>
+                        <fail msg="Drupal database connection not available." />
+                    </catch>
+                </trycatch>
+            </catch>
+        </trycatch>
     </target>
 
 

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -270,7 +270,7 @@ Or, you can specify the export file directly:
     <target name="drupal-first-install" depends="set-site" hidden="true">
         <fail unless="drupal.site.admin_user" />
 
-        <symlink link="${build.dir}/${drupal.root}/modules/contrib/the_build_utility" target="${build.thebuild.dir}/defaults/standard/modules/the_build_utility" />
+        <symlink link="${build.dir}/${drupal.root}/modules/contrib/the_build_utility" target="${build.thebuild.dir}/defaults/standard/modules/the_build_utility" relative="true" />
 
         <composer command="require" composer="${composer.composer}">
             <arg value="drupal/admin_toolbar" />

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -183,10 +183,25 @@ Or, you can specify the export file directly:
          the permissions, the database will be created.
          -->
     <target name="drupal-has-database-connection" depends="set-site" hidden="true">
+
+        <!-- We have to format the test query differently when using "ddev drush" vs. when using "drush" directly. -->
+        <property name="test_query" value="SELECT 1" />
+        <exec command="which ddev" returnProperty="which_ddev" />
+        <if>
+            <and>
+                <available file="${build.dir}/.ddev/config.yaml" />
+                <equals arg1="${which_ddev}" arg2="0" />
+                <not><isset property="env.IS_DDEV_PROJECT" /></not>
+            </and>
+            <then>
+                <property name="test_query" override="true">\"SELECT 1\"</property>
+            </then>
+        </if>
+
         <trycatch>
             <try>
                 <drush command="sql-query">
-                    <param>SELECT 1</param>
+                    <param>${test_query}</param>
                 </drush>
                 <echo msg="Drupal database connection available." />
             </try>

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -31,11 +31,8 @@
       <!-- Assembling this property at run time. -->
       <property name="drupal.validate_clean_config.dir" value="${build.dir}/${drupal.root}/${drupal.site.config_sync_directory}" />
 
-        <!-- Use git to list local (not yet committed) changes to the config
-             directory. Suppress errors so that this command will run even if
-             the project isn't a git directory (e.g. on the-build's CircleCI
-             test!) -->
-        <exec command="git status --porcelain ${drupal.validate_clean_config.dir} 2>/dev/null" outputProperty="modified_files" />
+        <!-- Use git to list local (not yet committed) changes to the config directory. -->
+        <exec command="git status --porcelain ${drupal.validate_clean_config.dir}" outputProperty="modified_files" />
 
         <if>
             <and>

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -179,34 +179,23 @@ Or, you can specify the export file directly:
 
     <!-- Target: drupal-has-database-connection
 
-         Check for a Drupal database connection. If the database doesn't exist and we have
-         the permissions, the database will be created.
+         Check for a Drupal database connection.
          -->
     <target name="drupal-has-database-connection" depends="set-site" hidden="true">
-        <trycatch>
-            <try>
-                <drush command="sql-query">
-                    <param>SELECT 1</param>
-                </drush>
+        <drush command="status" returnProperty="drupal_has_database_connection">
+            <option name="fields" value="db-status" />
+            <option name="format" value="string" />
+        </drush>
+
+        <if>
+            <equals arg1="${drupal_has_database_connection}" arg2="Connected" />
+            <then>
                 <echo msg="Drupal database connection available." />
-            </try>
-            <catch>
-                <trycatch>
-                    <try>
-                        <!-- If there's a database and it is accessible, this code will
-                             not be run. This code can help with setting up new
-                             multisites, since they will use new databases that may or may
-                             not exist yet.
-                             -->
-                        <drush command="sql-create" assume="yes" />
-                        <echo msg="Drupal database connection available." />
-                    </try>
-                    <catch>
-                        <fail msg="Drupal database connection not available." />
-                    </catch>
-                </trycatch>
-            </catch>
-        </trycatch>
+            </then>
+            <else>
+                <fail msg="Drupal database connection not available." />
+            </else>
+        </if>
     </target>
 
 

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -31,8 +31,11 @@
       <!-- Assembling this property at run time. -->
       <property name="drupal.validate_clean_config.dir" value="${build.dir}/${drupal.root}/${drupal.site.config_sync_directory}" />
 
-        <!-- Use git to list local (not yet committed) changes to the config directory. -->
-        <exec command="git status --porcelain ${drupal.validate_clean_config.dir}" outputProperty="modified_files" />
+        <!-- Use git to list local (not yet committed) changes to the config
+             directory. Suppress errors so that this command will run even if
+             the project isn't a git directory (e.g. on the-build's CircleCI
+             test!) -->
+        <exec command="git status --porcelain ${drupal.validate_clean_config.dir} 2>/dev/null" outputProperty="modified_files" />
 
         <if>
             <and>

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -165,6 +165,9 @@
 
     <!-- Target: setup-templates -->
     <target name="setup-templates" depends="set-site">
+        <!-- Set the project name in the ddev config. -->
+        <replaceregexp match="name: .*" replace="name: ${projectname}" file=".ddev/config.yaml" />
+
         <!-- Copy the build file template.
 
              This doesn't do any property substitution except for the "projectname",

--- a/targets/the-build.xml
+++ b/targets/the-build.xml
@@ -87,11 +87,18 @@
     <!-- Use the project directory name as the project name, if it's not configured. -->
     <basename property="projectname" file="${build.dir}" suffix="local" />
 
-    <!-- Configure the 'drush' Phing task. -->
+    <!-- Configure the 'drush' Phing task. By default, we run the installed drush. -->
     <property name="drush.bin" value="${build.dir}/vendor/bin/drush" />
-    <property name="drush.root" value="${build.dir}/${drupal.root}" />
-    <property name="drush.config" value="${build.dir}/drush/drushrc.php" />
-
+    <!-- If this is a ddev project, and we're outside of ddev, run ddev's drush command instead.  -->
+    <if>
+        <and>
+            <available file="${build.dir}/.ddev/config.yaml" />
+            <not><isset property="env.IS_DDEV_PROJECT" /></not>
+        </and>
+        <then>
+            <property name="drush.bin" value="ddev drush" override="true" />
+        </then>
+    </if>
 
     <!-- Configure the composer command, depending on whether `composer` or `composer.phar` is available. -->
     <exec command="command -v composer" outputProperty="composer.path.composer" />

--- a/targets/the-build.xml
+++ b/targets/the-build.xml
@@ -90,9 +90,11 @@
     <!-- Configure the 'drush' Phing task. By default, we run the installed drush. -->
     <property name="drush.bin" value="${build.dir}/vendor/bin/drush" />
     <!-- If this is a ddev project, and we're outside of ddev, run ddev's drush command instead.  -->
+    <exec command="which ddev" returnProperty="which_ddev" />
     <if>
         <and>
             <available file="${build.dir}/.ddev/config.yaml" />
+            <equals arg1="${which_ddev}" arg2="0" />
             <not><isset property="env.IS_DDEV_PROJECT" /></not>
         </and>
         <then>


### PR DESCRIPTION
If this is a ddev project, and we're outside of ddev, run ddev's drush command from phing instead of running drush directly.

After merging, we'll need to update and merge https://github.com/palantirnet/drupal-skeleton/pull/121 in palantirnet/drupal-skeleton.

This actually seems to work! You can test this with:

### Set up the codebase
```
composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction
cd example
composer require --dev palantirnet/the-build:dev-detect-ddev
ddev start
vendor/bin/the-build-installer
```

### Install Drupal at the prompt
When you're prompted to _Install Drupal now (y,n)?_, say _y_.

### The site has been installed without ever logging in to ddev
Visit https://example.ddev.site/

### Run other phing commands
For example:
```
vendor/bin/phing install -Ddrupal.validate_clean_config.bypass=yes
```
