### PR TITLE
Match drupal/devel version in drupal-first-install to skeleton

### DIFF
--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -260,7 +260,7 @@ Or, you can specify the export file directly:
         <composer command="require" composer="${composer.composer}">
             <arg value="drupal/admin_toolbar" />
             <arg value="drupal/config_split" />
-            <arg value="drupal/devel:^3.0" />
+            <arg value="drupal/devel:^3.0@dev" />
             <arg value="drupal/workbench" />
             <arg value="drupal/workbench_tabs" />
         </composer>


### PR DESCRIPTION
## Description

* FIxes an issue where running `phing drupal-first-install` (or answering "Y" when prompted to install Drupal during `the-build-installer`) fails with a Composer error. The skeleton uses the constraint `^3.0@dev` while `drupal-first-install` used `^3.0`. This updates the Phing target to use the dev version to match the skeleton.

*Note: This may not be a long-term fix, as the Drupal Skeleton may need to be changed to use a stable version of Devel at some point in the future. When that happens, this will need to be updated again.*

## Testing

- `composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction`
- Edit `.ddev/config.yaml` and set the `name` to `example`.
- `ddev start`
- `ddev ssh`
- `vendor/bin/the-build-installer`
- Choose to install Drupal for the first time.
- Verifiy the installation completes successfully.