### PR TITLE
Update devel module to 4.1.x for D9 support.

### DIFF
--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -260,7 +260,7 @@ Or, you can specify the export file directly:
         <composer command="require" composer="${composer.composer}">
             <arg value="drupal/admin_toolbar" />
             <arg value="drupal/config_split" />
-            <arg value="drupal/devel:^3.0" />
+            <arg value="drupal/devel" />
             <arg value="drupal/workbench" />
             <arg value="drupal/workbench_tabs" />
         </composer>


### PR DESCRIPTION
# Description

* `/targets/drupal.xml` has a hard dependency on Devel 3.0; however, this version does not offer D9 support. I have instead removed this dependency in order to allow 4.1.x to be used.
* This is tangentially related to https://github.com/palantirnet/drupal-skeleton/pull/118, so these should both be merged at the same time. Please follow the testing instructions in that PR in order to test this PR as well.