### PR TITLE
Use new CircleCI convenience image for PHP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Install packages
           command: |
-            sudo sudo apt-get update && apt-get install -y libpng-dev default-mysql-client
+            sudo apt-get update && apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Configure PHP
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     working_directory: ~/example
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
       - image: circleci/mysql:5.7-ram
         command: --max_allowed_packet=16M
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Install packages
           command: |
-            sudo apt-get update && apt-get install -y libpng-dev default-mysql-client
+            sudo apt-get update && sudo apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Configure PHP
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             sudo apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Install PHP extensions
-          command: sudo docker-php-ext-install pdo_mysql gd
+          command: sudo pecl install pdo_mysql gd
       - run:
           name: Configure PHP
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,6 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libpng-dev default-mysql-client
       - run:
-          name: Install PHP extensions
-          command: sudo pecl install pdo_mysql gd
-      - run:
           name: Configure PHP
           command: |
             echo "sendmail_path=/bin/true" | sudo tee -a "/usr/local/etc/php/php.ini"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # This CircleCI configuration is for testing the-build itself. For the configuration
 # installed in projects, see defaults/install/.circleci/config.yml
 
-version: 2
+version: 2.1
 jobs:
   build:
     working_directory: ~/example

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: ~/example
     docker:
       - image: cimg/php:7.4-browsers
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/mysql:5.7
         command: --max_allowed_packet=16M
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
@@ -22,8 +22,7 @@ jobs:
       - run:
           name: Install packages
           command: |
-            sudo apt-get update
-            sudo apt-get install -y libpng-dev default-mysql-client
+            sudo sudo apt-get update && apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Configure PHP
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,7 @@ jobs:
       - run:
           name: Configure PHP
           command: |
-            echo "sendmail_path=/bin/true" | sudo tee -a "/usr/local/etc/php/php.ini"
-            echo "memory_limit=-1" | sudo tee -a "/usr/local/etc/php/php.ini"
+            echo "sendmail_path=/bin/true" | sudo tee -a "/etc/php.d/circleci.ini"
       - run:
           name: Create artifacts directory
           command: mkdir /tmp/artifacts

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Install packages
           command: |
-            sudo sudo apt-get update && apt-get install -y libpng-dev default-mysql-client
+            sudo apt-get update && apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Install nvm
           command: |

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -3,8 +3,8 @@ jobs:
   build:
     working_directory: ~/${projectname}
     docker:
-      - image: circleci/php:7.3-node-browsers
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/php:7.4-node-browsers
+      - image: cimg/mysql:5.7
         command: --max_allowed_packet=16M
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
@@ -20,8 +20,7 @@ jobs:
       - run:
           name: Install packages
           command: |
-            sudo apt-get update
-            sudo apt-get install -y libpng-dev default-mysql-client
+            sudo sudo apt-get update && apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Install nvm
           command: |
@@ -31,13 +30,9 @@ jobs:
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
-          name: Install PHP extensions
-          command: sudo docker-php-ext-install pdo_mysql gd
-      - run:
           name: Configure PHP
           command: |
-            echo "sendmail_path=/bin/true" | sudo tee -a "/usr/local/etc/php/php.ini"
-            echo "memory_limit=-1" | sudo tee -a "/usr/local/etc/php/php.ini"
+            echo "sendmail_path=/bin/true" | sudo tee -a "/etc/php.d/circleci.ini"
       - run:
           name: Create artifacts directory
           command: mkdir /tmp/artifacts

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Install packages
           command: |
-            sudo apt-get update && apt-get install -y libpng-dev default-mysql-client
+            sudo apt-get update && sudo apt-get install -y libpng-dev default-mysql-client
       - run:
           name: Install nvm
           command: |

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -1,4 +1,10 @@
-version: 2
+version: 2.1
+# To use browsers on CircleCI, uncomment the lines below and add steps to install them.
+# For example, add these to `jobs.build.steps`:
+# - browser-tools/install-chrome
+# - browser-tools/install-chromedriver
+# orbs:
+#   browser-tools: circleci/browser-tools@1.2.3
 jobs:
   build:
     working_directory: ~/${projectname}

--- a/defaults/install/.circleci/deploy-acquia-example
+++ b/defaults/install/.circleci/deploy-acquia-example
@@ -21,7 +21,7 @@
   deploy:
     working_directory: ~/project
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: cimg/php:7.4-node-browsers
     environment:
       - NODE_VERSION: 8
       - GITHUB_PUBKEY: "github.com,192.30.253.113 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="

--- a/defaults/install/.circleci/deploy-acquia-example
+++ b/defaults/install/.circleci/deploy-acquia-example
@@ -33,7 +33,7 @@
       - add_ssh_keys
       - run:
           name: Install packages
-          command: sudo apt-get install -y libpng-dev
+          command: sudo apt-get update && sudo apt-get install -y libpng-dev
 
       - run:
           name: Install nvm
@@ -44,12 +44,9 @@
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
-          name: Install PHP extensions
-          command: sudo docker-php-ext-install gd
-      - run:
           name: Configure PHP
           command: |
-            echo "memory_limit=-1" | sudo tee -a "/usr/local/etc/php/php.ini"
+            echo "sendmail_path=/bin/true" | sudo tee -a "/etc/php.d/circleci.ini"
       - run:
           name: Configure Git
           command: |

--- a/defaults/install/.circleci/deploy-acquia-example
+++ b/defaults/install/.circleci/deploy-acquia-example
@@ -21,7 +21,7 @@
   deploy:
     working_directory: ~/project
     docker:
-      - image: cimg/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     environment:
       - NODE_VERSION: 8
       - GITHUB_PUBKEY: "github.com,192.30.253.113 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="

--- a/defaults/install/.circleci/deploy-pantheon.example
+++ b/defaults/install/.circleci/deploy-pantheon.example
@@ -23,7 +23,7 @@
   deploy:
     working_directory: ~/project
     docker:
-      - image: circleci/php:7.2-node-browsers
+      - image: cimg/php:7.4-node-browsers
     environment:
       - NODE_VERSION: 8
       - GITHUB_PUBKEY: "github.com,192.30.253.113 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="

--- a/defaults/install/.circleci/deploy-pantheon.example
+++ b/defaults/install/.circleci/deploy-pantheon.example
@@ -23,7 +23,7 @@
   deploy:
     working_directory: ~/project
     docker:
-      - image: cimg/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     environment:
       - NODE_VERSION: 8
       - GITHUB_PUBKEY: "github.com,192.30.253.113 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="

--- a/defaults/install/.circleci/deploy-pantheon.example
+++ b/defaults/install/.circleci/deploy-pantheon.example
@@ -35,7 +35,7 @@
       - add_ssh_keys
       - run:
           name: Install packages
-          command: sudo apt-get install -y libpng-dev
+          command: sudo apt-get update && sudo apt-get install -y libpng-dev
 
       - run:
           name: Install nvm
@@ -46,12 +46,9 @@
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
-          name: Install PHP extensions
-          command: sudo docker-php-ext-install gd
-      - run:
           name: Configure PHP
           command: |
-            echo "memory_limit=-1" | sudo tee -a "/usr/local/etc/php/php.ini"
+            echo "sendmail_path=/bin/true" | sudo tee -a "/etc/php.d/circleci.ini"
       - run:
           name: Configure Git
           command: |

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -260,7 +260,7 @@ Or, you can specify the export file directly:
         <composer command="require" composer="${composer.composer}">
             <arg value="drupal/admin_toolbar" />
             <arg value="drupal/config_split" />
-            <arg value="drupal/devel:^3.0" />
+            <arg value="drupal/devel:^3.0@dev" />
             <arg value="drupal/workbench" />
             <arg value="drupal/workbench_tabs" />
         </composer>


### PR DESCRIPTION
See https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

Todo:

- [x] Update `defaults/install/.circleci/config.yml`
- [x] Maybe add a comment with a link to the orb documentation for installing browsers?
- [x] ~Maybe add a comment about when the mysql image will get a cimg version?~ Update for new MySQL image.
- [x] The devel version issue should be resolved in the `develop` branch now