### PR TITLE
Patch Phing to fix relative symlinks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "extra": {
         "patches": {
             "phing/phing": {
-                "Support relative symliks in Phing": "patches/phing-relative-symlinks.patch"
+                "Support relative symliks in Phing": "https://raw.githubusercontent.com/palantirnet/the-build/7cdc28b6019fb88a0604261366f9ea35f1e21d96/patches/phing-relative-symlinks.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,10 @@
         "bin/the-build-installer"
     ],
     "require": {
-        "palantirnet/phing-drush-task": "^1.1",
+        "cweagans/composer-patches": "^1.7",
         "drupal/coder": "^8.3.6",
         "drush/drush": "^9 || ^10",
+        "palantirnet/phing-drush-task": "^1.1",
         "pear/http_request2": "^2.3",
         "pear/versioncontrol_git": "@dev",
         "phing/phing": "^2.14",
@@ -27,5 +28,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "patches": {
+            "phing/phing": {
+                "Support relative symliks in Phing": "patches/phing-relative-symlinks.patch"
+            }
+        }
     }
 }

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -45,7 +45,7 @@
 
         <!-- Include styleguide resources in the theme. This approach will symlink
              resources in development environments, and copy them for artifact builds. -->
-        <!-- <includeresource source="styleguide/source/assets/css" dest="${drupal.root}/themes/custom/example_theme/css" /> -->
+        <!-- <includeresource relative="true" source="${build.dir}/styleguide/source/assets/css" dest="${build.dir}/${drupal.root}/themes/custom/example_theme/css" /> -->
     </target>
 
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,9 @@
+### phing-relative-symlinks.patch
+
+Source: [https://github.com/phingofficial/phing/pull/695](https://github.com/phingofficial/phing/pull/695)
+
+This patch updates Phing's SymlinkTask to allow creating relative symlinks, using the syntax:
+
+```
+<symlink link="path/to/destination" target="path/to/target" relative="true" />
+```

--- a/patches/phing-relative-symlinks.patch
+++ b/patches/phing-relative-symlinks.patch
@@ -1,0 +1,76 @@
+diff --git a/classes/phing/tasks/ext/SymlinkTask.php b/classes/phing/tasks/ext/SymlinkTask.php
+index f132b4f747..87844a0d09 100644
+--- a/classes/phing/tasks/ext/SymlinkTask.php
++++ b/classes/phing/tasks/ext/SymlinkTask.php
+@@ -206,6 +206,46 @@ public function isRelative()
+         return $this->relative;
+     }
+ 
++    /**
++     * Given an existing path, convert it to a path relative to a given starting path.
++     *
++     * @param string $endPath   Absolute path of target
++     * @param string $startPath Absolute path where traversal begins
++     *
++     * @return string Path of target relative to starting path
++     */
++    public function makePathRelative($endPath, $startPath)
++    {
++        // Normalize separators on Windows
++        if ('\\' === DIRECTORY_SEPARATOR) {
++            $endPath = str_replace('\\', '/', $endPath);
++            $startPath = str_replace('\\', '/', $startPath);
++        }
++
++        // Split the paths into arrays
++        $startPathArr = explode('/', trim($startPath, '/'));
++        $endPathArr = explode('/', trim($endPath, '/'));
++
++        // Find for which directory the common path stops
++        $index = 0;
++        while (isset($startPathArr[$index]) && isset($endPathArr[$index]) && $startPathArr[$index] === $endPathArr[$index]) {
++            ++$index;
++        }
++
++        // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
++        $depth = count($startPathArr) - $index;
++
++        // Repeated "../" for each level need to reach the common path
++        $traverser = str_repeat('../', $depth);
++
++        $endPathRemainder = implode('/', array_slice($endPathArr, $index));
++
++        // Construct $endPath from traversing to the common path, then to the remaining $endPath
++        $relativePath = $traverser.('' !== $endPathRemainder ? $endPathRemainder.'/' : '');
++
++        return '' === $relativePath ? './' : $relativePath;
++    }
++
+     /**
+      * Generates an array of directories / files to be linked
+      * If _filesets is empty, returns getTarget()
+@@ -235,11 +275,7 @@ protected function getMap()
+                 throw new BuildException('Link must be an existing directory when using fileset');
+             }
+ 
+-            if ($this->isRelative()) {
+-                $fromDir = $fs->getDir($this->getProject())->getPath();
+-            } else {
+-                $fromDir = $fs->getDir($this->getProject())->getAbsolutePath();
+-            }
++            $fromDir = $fs->getDir($this->getProject())->getAbsolutePath();
+ 
+             if (!is_dir($fromDir)) {
+                 $this->log('Directory doesn\'t exist: ' . $fromDir, Project::MSG_WARN);
+@@ -300,6 +336,11 @@ protected function symlink($target, $link)
+     {
+         $fs = FileSystem::getFileSystem();
+ 
++        if ($this->isRelative()) {
++           $link =(new PhingFile($link))->getAbsolutePath();
++           $target = rtrim($this->makePathRelative($target, dirname($link)), '/');
++        }
++
+         if (is_link($link) && @readlink($link) == $target) {
+             $this->log('Link exists: ' . $link, Project::MSG_INFO);
+ 

--- a/src/TheBuild/IncludeResourceTask.php
+++ b/src/TheBuild/IncludeResourceTask.php
@@ -32,6 +32,12 @@ class IncludeResourceTask extends \Task {
    */
   protected $dest = NULL;
 
+  /**
+   * Whether to create relative symlinks
+   *
+   * @var boolean
+   */
+  private $relative = false;
 
   /**
    * Init tasks.
@@ -43,6 +49,10 @@ class IncludeResourceTask extends \Task {
     $mode = $this->getProject()->getProperty('includeresource.mode');
     if (!is_null($mode)) {
       $this->setMode($mode);
+    }
+    $relative = $this->getProject()->getProperty('includeresource.relative');
+    if (!is_null($relative)) {
+      $this->setRelative($relative);
     }
   }
 
@@ -70,7 +80,11 @@ class IncludeResourceTask extends \Task {
     }
     else {
       $this->log(sprintf("Linking '%s' to '%s'", $this->source->getPath(), $this->dest->getPath()));
-      FileSystem::getFileSystem()->symlink($this->source->getPath(), $this->dest->getPath());
+      $symlink_task = $this->project->createTask("symlink");
+      $symlink_task->setTarget($this->source->getPath());
+      $symlink_task->setLink($this->dest->getPath());
+      $symlink_task->setRelative($this->relative);
+      $symlink_task->main();
     }
   }
 
@@ -120,6 +134,14 @@ class IncludeResourceTask extends \Task {
    */
   public function setDest(PhingFile $dest) {
     $this->dest = $dest;
+  }
+
+  /**
+   * @param boolean $relative
+   */
+  public function setRelative($relative)
+  {
+      $this->relative = $relative;
   }
 
 }

--- a/src/TheBuild/IncludeResourceTask.php
+++ b/src/TheBuild/IncludeResourceTask.php
@@ -37,7 +37,7 @@ class IncludeResourceTask extends \Task {
    *
    * @var boolean
    */
-  private $relative = false;
+  private $relative = true;
 
   /**
    * Init tasks.

--- a/src/TheBuild/IncludeResourceTask.php
+++ b/src/TheBuild/IncludeResourceTask.php
@@ -37,7 +37,7 @@ class IncludeResourceTask extends \Task {
    *
    * @var boolean
    */
-  private $relative = true;
+  protected $relative = true;
 
   /**
    * Init tasks.

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -270,7 +270,7 @@ Or, you can specify the export file directly:
     <target name="drupal-first-install" depends="set-site" hidden="true">
         <fail unless="drupal.site.admin_user" />
 
-        <symlink link="${build.dir}/${drupal.root}/modules/contrib/the_build_utility" target="${build.thebuild.dir}/defaults/standard/modules/the_build_utility" />
+        <symlink link="${build.dir}/${drupal.root}/modules/contrib/the_build_utility" target="${build.thebuild.dir}/defaults/standard/modules/the_build_utility" relative="true" />
 
         <composer command="require" composer="${composer.composer}">
             <arg value="drupal/admin_toolbar" />


### PR DESCRIPTION
#### Description

* Fixes issues discovered in https://github.com/palantirnet/the-build/pull/174.
* Patches Phing to fix support for relative symlinks (according to https://github.com/phingofficial/phing/pull/695, which was only added to Phing 3).
* Uses a relative symlink for `the_build_utility` module, so it will be correct inside the DDEV container when created outside.
* Updates `IncludeResourceTask` to use `SymlinkTask` in order to take advantage of required relative symlinks.

This also requires adding `cweagans/composer-patches` and the following line to `composer.json`, so the skeleton will need to be updated:
```
"extra": {
    "enable-patching": true
}
```

#### Testing instructions

* Create a new project using Composer, or use an existing one. Backup your database if using an existing project, and you want to keep it.
* `composer require cweagans/composer-patches`
* Add `"enable-patching": true` to the `"extra": { }` section of `composer.json`
* Change the version of The Build in `composer.json` to `"palantirnet/the-build": "dev-detect-ddev-byron"`.
* `composer update palantirnet/the-build` (You should see Composer remove Phing, reinstall it, and add the patch.)
* `ddev start` (if the project isn't already running)
* `ddev drush sql-drop`
* `vendor/bin/the-build-installer`
* Use defaults (or settings that match your existing project). Choose to install Drupal when prompted.