### PR TITLE
Change the behat command to use depending on whether ddev is available.

### DIFF
--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -103,7 +103,7 @@
 
     <!-- Target: behat -->
     <target name="behat" description="Run the Behat tests.">
-        <property name="behat.command" value="vendor/bin/behat ${behat.args}" />
+        <property name="behat.command" value="${behat.bin} ${behat.args}" />
         <echo msg="$> ${behat.command}" />
         <exec command="${behat.command}" logoutput="true" checkreturn="true" />
     </target>

--- a/targets/the-build.xml
+++ b/targets/the-build.xml
@@ -87,9 +87,11 @@
     <!-- Use the project directory name as the project name, if it's not configured. -->
     <basename property="projectname" file="${build.dir}" suffix="local" />
 
-    <!-- Configure the 'drush' Phing task. By default, we run the installed drush. -->
+    <!-- Configure binaries to run depending on whether we're inside of ddev or out. -->
     <property name="drush.bin" value="${build.dir}/vendor/bin/drush" />
-    <!-- If this is a ddev project, and we're outside of ddev, run ddev's drush command instead.  -->
+    <property name="behat.bin" value="${build.dir}/vendor/bin/behat" />
+
+    <!-- If this is a ddev project, and we're outside of ddev, run these commands within ddev.  -->
     <exec command="which ddev" returnProperty="which_ddev" />
     <if>
         <and>
@@ -99,6 +101,7 @@
         </and>
         <then>
             <property name="drush.bin" value="ddev drush" override="true" />
+            <property name="behat.bin" value="ddev . vendor/bin/behat" override="true" />
         </then>
     </if>
 


### PR DESCRIPTION
Followup to #174; this does the same thing for behat as we did for drush, so that behat is run in an environment that can access the Drupal application directly.

To test...


### Set up the codebase
```
composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction
cd example
composer require --dev palantirnet/the-build:dev-run-behat-inside-ddev
ddev start
vendor/bin/the-build-installer
```

### Install Drupal at the prompt
When you're prompted to _Install Drupal now (y,n)?_, say _y_.

The site should be available at https://example.ddev.site/

### Run the behat test command:
```
vendor/bin/phing behat
```
