### PR TITLE
Add drupal check dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,7 @@ jobs:
       # Use this copy of the-build
       - run:
           name: Replace the default version of the-build with this one
-          command: rm -r vendor/palantirnet/the-build
-
-      - checkout:
-          path: ~/example/vendor/palantirnet/the-build
+          command: composer require --dev palantirnet/the-build:dev-${CIRCLE_BRANCH}
 
       # Source cache - update when branch changes
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       # Use this copy of the-build
       - run:
           name: Replace the default version of the-build with this one
-          command: composer require --dev palantirnet/the-build:dev-${CIRCLE_BRANCH}
+          command: composer require --dev --with-all-dependencies palantirnet/the-build:dev-${CIRCLE_BRANCH}
 
       # Source cache - update when branch changes
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,18 +39,6 @@ jobs:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 example.ddev.site | sudo tee -a /etc/hosts
 
-      # Note: phing and drupal-check have mutually exclusive requirements.
-      # It'd be better to add drupal-check as a dependency of the drupal project
-      # rather than as part of the virtual environment, but this will have to do
-      # for now. Also note, drupal-check is added as part of the-vagrant so it
-      # is available to run within our VM.
-      # Note 2: drupal-check is pinned to a known stable version.
-      - run:
-          name: Install drupal-check
-          command: |
-            composer global require mglaman/drupal-check
-            ln -s ~/.config/composer/vendor/bin ~/bin
-
       # Composer package cache
       - restore_cache:
           keys:

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/coder": "^8.3.6",
         "drush/drush": "^9 || ^10",
+        "mglaman/drupal-check": "^1.2",
         "palantirnet/phing-drush-task": "^1.1",
         "pear/http_request2": "^2.3",
         "pear/versioncontrol_git": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "pear/http_request2": "^2.3",
         "pear/versioncontrol_git": "@dev",
         "phing/phing": "^2.14",
-        "phpmd/phpmd": "^2.4"
+        "phpmd/phpmd": "^2.4",
+        "phpspec/prophecy-phpunit": "^2"
     },
     "autoload": {
         "psr-0": {

--- a/defaults.yml
+++ b/defaults.yml
@@ -267,11 +267,11 @@ phpmd:
 # Configuration for checking the site with the Drupal Checker code linter.
 #
 # @see https://github.com/mglaman/drupal-check
-# These values are used in the defaults/build.xml template.
+# @see defaults/build.xml
 drupal-check:
-  # Location of the drupal-check script. This script is currently installed globally
-  # because of repository-level composer conflicts.
-  bin: "~/bin/drupal-check"
+  # Location of the drupal-check script. This shouldn't need to be overridden,
+  # but it is used in the defaults/build.xml template.
+  bin: "vendor/bin/drupal-check"
   # Comma separated list of directories
   directories: "${drupal.root}/modules/custom/,${drupal.root}/themes/custom/"
 

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -45,20 +45,6 @@ jobs:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
 
-      # Note: phing and drupal-check have mutually exclusive requirements.
-      # It'd be better to add drupal-check as a dependency of the drupal project
-      # rather than as part of the virtual environment, but this will have to do
-      # for now. Also note, drupal-check is added as part of the-vagrant so it
-      # is available to run within our VM.
-      # Note 2: drupal-check is pinned to a known stable version.
-      - run:
-          name: Install drupal-check
-          command: |
-            curl -O -L https://github.com/mglaman/drupal-check/releases/download/1.0.9/drupal-check.phar
-            mkdir --parents ~/bin
-            mv drupal-check.phar ~/bin/drupal-check
-            chmod +x ~/bin/drupal-check
-
       # Composer package cache
       - restore_cache:
           keys:

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -134,8 +134,9 @@
     <!-- Separated out so that we can use foreach. drupal-check only accepts a single directory argument. -->
     <target name="drupal-check" hidden="true">
         <fail unless="drupal-check.dir" />
-        <property name="drupal-check.bin" value="~/bin/drupal-check" />
+        <property name="drupal-check.bin" value="vendor/bin/drupal-check" />
         <property name="drupal-check.command" value="${drupal-check.bin} ${drupal-check.dir}" />
+
         <echo msg="$> ${drupal-check.command}" />
         <exec command="${drupal-check.command}" logoutput="true" checkreturn="true" />
     </target>

--- a/defaults/install/the-build/build.circleci.yml
+++ b/defaults/install/the-build/build.circleci.yml
@@ -13,6 +13,3 @@ drupal:
 
 behat:
   args: "--profile=circleci --suite=default --strict --format=junit --out=/tmp/artifacts --tags=~@skipci"
-
-drupal-check:
-  bin: "/home/circleci/bin/drupal-check"

--- a/defaults/install/the-build/build.yml
+++ b/defaults/install/the-build/build.yml
@@ -53,13 +53,6 @@ drupal:
 behat:
   args: "--suite=default --strict"
 
-# Configuration for checking the site with the Drupal Checker code linter.
-drupal-check:
-  # Location of the drupal-check script. This script is currently installed globally
-  # on the-vagrant because of repository-level composer conflicts.
-  bin: "~/bin/drupal-check"
-
-
 # To build an artifact from your code, add the URL to your artifact git repository.
 # @see https://github.com/palantirnet/the-build/blob/release-2.0/defaults.yml
 #


### PR DESCRIPTION
Add mglaman/drupal-check as a dependency, since Phing dependencies no longer conflict with drupal-check dependencies. This means that we no longer have to do gymnastics around finding the location of the drupal-check bin on whatever system we're running on (localhost, ddev, vagrant, circleci).

To test:

```
composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction
cd example
composer require --dev palantirnet/the-build:dev-add-drupal-check-dependency
vendor/bin/the-build-installer
vendor/bin/phing code-review
```
