### PR TITLE
Fail build when there are errors

### DIFF
--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -152,7 +152,7 @@
 
     <!-- Target: artifact -->
     <target name="artifact" description="Build and deploy the application.">
-        <phing phingfile="build.xml" target="artifact-main" inheritAll="false">
+        <phing phingfile="build.xml" target="artifact-main" inheritAll="false" haltonfailure="true">
             <property name="build.env" value="@host@" />
         </phing>
     </target>

--- a/targets/artifact.xml
+++ b/targets/artifact.xml
@@ -252,7 +252,7 @@
             - Override the "artifact mode" so that files managed with the
               <includeresource /> task are copied into the artifact instead of symlinked.
             -->
-        <phing target="build" phingfile="${phing.file}" inheritAll="false" dir=".">
+        <phing target="build" phingfile="${phing.file}" inheritAll="false" dir="." haltonfailure="true">
             <property name="build.site" value="${site_key}" />
             <property name="drupal.root" value="${artifact.directory}/${drupal.root}" override="true" />
             <property name="includeresource.mode" value="copy" override="true" />

--- a/targets/styleguide.xml
+++ b/targets/styleguide.xml
@@ -24,7 +24,7 @@
         <if>
             <equals arg1="${styleguide.exists}" arg2="1" />
             <then>
-                <phingcall target="styleguide-build" />
+                <phing phingfile="styleguide.xml" target="styleguide-build" haltonfailure="true"/>
             </then>
             <else>
                 <echo>Skipping style guide build.</echo>

--- a/targets/styleguide.xml
+++ b/targets/styleguide.xml
@@ -24,7 +24,7 @@
         <if>
             <equals arg1="${styleguide.exists}" arg2="1" />
             <then>
-                <phing phingfile="styleguide.xml" target="styleguide-build" haltonfailure="true"/>
+                <phingcall target="styleguide-build" />
             </then>
             <else>
                 <echo>Skipping style guide build.</echo>


### PR DESCRIPTION
Currently, when the artifact build or style guide install fails, they do not generate an error that fails the build. This makes it look like all steps completed successfully on CI when there were actually errors.

* Sets `haltonfailure` to `true` for the call to `artifact-main` to make sure errors will stop the build.
- [x] TODO: Verify style guide build errors halt the build

## Testing
- `composer require palantirnet/the-build:dev-fail-on-build-errors`
- Update the following line in your project's `build.xml` file:
    `<phing phingfile="build.xml" target="artifact-main" inheritAll="false">`
    to read:
    `<phing phingfile="build.xml" target="artifact-main" inheritAll="false" haltonfailure="true">`
- Induce a styleguide build error.
- `phing artifact`
- Verify the artifact build fails.
- Fix the styleguide build error, and induce some other build error.
- `phing artifact`
- Verify the artifact build fails.