### PR TITLE
Updates phpcs config in defaults.yml

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -227,13 +227,17 @@ phplint:
 # @see https://www.drupal.org/project/coder
 #
 # These values are used in the defaults/build.xml template:
-#   $> phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}
+#   $> phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} --ignore=${phpcs.ignore} ${phpcs.directories}
 phpcs:
   # Path to a PHP_CodeSniffer standard file.
   standard: "${build.dir}/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml"
 
   # Space-separated list of directories to review.
   directories: "${drupal.root}/modules/custom ${drupal.root}/themes/custom"
+
+  # Comma-separated list of patterns for files and directories to exclude from the
+  # PHP_CodeSniffer review.
+  ignore: "*/vendor/*,*/node_modules/*"
 
   # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
   extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml,js"

--- a/defaults.yml
+++ b/defaults.yml
@@ -227,21 +227,13 @@ phplint:
 # @see https://www.drupal.org/project/coder
 #
 # These values are used in the defaults/build.xml template:
-#   $> phpcs --standard=${phpcs.standard} --ignore=${phpcs.ignore} ${phpcs.directories}
+#   $> phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}
 phpcs:
   # Path to a PHP_CodeSniffer standard file.
   standard: "${build.dir}/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml"
 
   # Space-separated list of directories to review.
   directories: "${drupal.root}/modules/custom ${drupal.root}/themes/custom"
-
-  # Comma-separated list of patterns for files and directories to exclude from the
-  # PHP_CodeSniffer review.
-  #
-  # This is deprecated and will be removed in 3.0, and build.xml will need to be updated then to
-  # use the extensions option (below). This option should not be used with Coder >= 8.3.7, which only
-  # checks php, inc, css, and js by default.
-  ignore: "*.md"
 
   # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
   extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml,js"

--- a/defaults.yml
+++ b/defaults.yml
@@ -227,17 +227,13 @@ phplint:
 # @see https://www.drupal.org/project/coder
 #
 # These values are used in the defaults/build.xml template:
-#   $> phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} --ignore=${phpcs.ignore} ${phpcs.directories}
+#   $> phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}
 phpcs:
   # Path to a PHP_CodeSniffer standard file.
   standard: "${build.dir}/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml"
 
   # Space-separated list of directories to review.
   directories: "${drupal.root}/modules/custom ${drupal.root}/themes/custom"
-
-  # Comma-separated list of patterns for files and directories to exclude from the
-  # PHP_CodeSniffer review.
-  ignore: "*/vendor/*,*/node_modules/*"
 
   # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
   extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml,js"

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -117,7 +117,7 @@
         </phplint>
 
         <!-- Run PHP Code Sniffer. -->
-        <property name="phpcs.command" value="vendor/bin/phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} --ignore=${phpcs.ignore} ${phpcs.directories}" />
+        <property name="phpcs.command" value="vendor/bin/phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}" />
         <echo msg="$> ${phpcs.command}" />
         <exec command="${phpcs.command}" logoutput="true" checkreturn="true" />
 

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -117,7 +117,7 @@
         </phplint>
 
         <!-- Run PHP Code Sniffer. -->
-        <property name="phpcs.command" value="vendor/bin/phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}" />
+        <property name="phpcs.command" value="vendor/bin/phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} --ignore=${phpcs.ignore} ${phpcs.directories}" />
         <echo msg="$> ${phpcs.command}" />
         <exec command="${phpcs.command}" logoutput="true" checkreturn="true" />
 


### PR DESCRIPTION
* Fixes https://github.com/palantirnet/the-build/issues/157 by updating the comments to reference the new `extensions` config.
* Removes the deprecated `ignore` config.