### PR TITLE
Fix shell script installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ jobs:
           command: |
             echo "sendmail_path=/bin/true" | sudo tee -a "/etc/php.d/circleci.ini"
       - run:
+          name: Update Composer
+          command: |
+            sudo composer self-update
+      - run:
           name: Create artifacts directory
           command: mkdir /tmp/artifacts
       - run:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ _Note: If you are starting a new a project, you may be looking for the [drupal-s
 $> composer require palantirnet/the-build
 ```
 
+Composer 2.2.2 or greater is required for the-build.
+
 ## Setting up
 
 Install the default templates and phing targets to your project:

--- a/bin/the-build-installer
+++ b/bin/the-build-installer
@@ -2,9 +2,23 @@
 #
 # Wrapper for our install command; at least this way it's somewhat discoverable.
 #
-# Essentially, this runs:
+# The install command boils down to:
 #   vendor/bin/phing -f vendor/palantirnet/the-build/targets/install.xml
 #
-# This script assumes that the composer bin dir is at vendor/bin/.
+# This script is "weird", because:
+# * Script proxying was added in Composer 2.2.0
+# * The environment variable COMPOSER_BIN_DIR was added in Composer 2.2.2
+# * The environment variable was changed to COMPOSER_RUNTIME_BIN_DIR in Composer 2.2.7
+# * This script assumes the composer bin dir is at vendor/bin/
 
-(cd $COMPOSER_BIN_DIR/../../ && $COMPOSER_BIN_DIR/phing -f $COMPOSER_BIN_DIR/../palantirnet/the-build/targets/install.xml)
+# Composer 2.2.2 through 2.2.6
+if [ "$COMPOSER_BIN_DIR" != "" ]; then
+  COMPOSER_RUNTIME_BIN_DIR="$COMPOSER_BIN_DIR"
+fi
+
+if [ "$COMPOSER_RUNTIME_BIN_DIR" = "" ]; then
+  echo "Please update to at least Composer version 2.2.2"
+  exit 1
+fi
+
+(cd $COMPOSER_RUNTIME_BIN_DIR/../../ && $COMPOSER_RUNTIME_BIN_DIR/phing -f $COMPOSER_RUNTIME_BIN_DIR/../palantirnet/the-build/targets/install.xml)

--- a/bin/the-build-installer
+++ b/bin/the-build-installer
@@ -5,20 +5,13 @@
 # The install command boils down to:
 #   vendor/bin/phing -f vendor/palantirnet/the-build/targets/install.xml
 #
-# This script is "weird", because:
-# * Script proxying was added in Composer 2.2.0
-# * The environment variable COMPOSER_BIN_DIR was added in Composer 2.2.2
-# * The environment variable was changed to COMPOSER_RUNTIME_BIN_DIR in Composer 2.2.7
+# * This script requires Composer 2.2.2 or greater, because of a series of script proxying
+#   changes between 2.1.x and 2.2.2. This requirement is enforced in composer.json.
 # * This script assumes the composer bin dir is at vendor/bin/
 
 # Composer 2.2.2 through 2.2.6
 if [ "$COMPOSER_BIN_DIR" != "" ]; then
   COMPOSER_RUNTIME_BIN_DIR="$COMPOSER_BIN_DIR"
-fi
-
-if [ "$COMPOSER_RUNTIME_BIN_DIR" = "" ]; then
-  echo "Please update to at least Composer version 2.2.2"
-  exit 1
 fi
 
 (cd $COMPOSER_RUNTIME_BIN_DIR/../../ && $COMPOSER_RUNTIME_BIN_DIR/phing -f $COMPOSER_RUNTIME_BIN_DIR/../palantirnet/the-build/targets/install.xml)

--- a/bin/the-build-installer
+++ b/bin/the-build-installer
@@ -1,20 +1,10 @@
 #!/bin/sh
 #
 # Wrapper for our install command; at least this way it's somewhat discoverable.
-# Previously:
+#
+# Essentially, this runs:
 #   vendor/bin/phing -f vendor/palantirnet/the-build/targets/install.xml
+#
+# This script assumes that the composer bin dir is at vendor/bin/.
 
-# Relative path to this script.
-SCRIPT=$(readlink "$0")
-
-# Absolute path to this script's parent directory.
-SCRIPTPATH=$(cd `dirname $0` && cd `dirname $SCRIPT` && pwd)
-
-REPOPATH=$(cd `dirname $SCRIPTPATH` && cd ../../../ && pwd)
-
-if [ "$REPOPATH" = `pwd` ]; then
-  # Run our install task.
-  $SCRIPTPATH/../../../bin/phing -f $SCRIPTPATH/../targets/install.xml
-else
-  echo "Please run this command from your project root."
-fi
+(cd $COMPOSER_BIN_DIR/../../ && $COMPOSER_BIN_DIR/phing -f $COMPOSER_BIN_DIR/../palantirnet/the-build/targets/install.xml)

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "bin/the-build-installer"
     ],
     "require": {
+        "composer-runtime-api": "^2.2.2",
         "cweagans/composer-patches": "^1.7",
         "drupal/coder": "^8.3.6",
         "drush/drush": "^9 || ^10",
@@ -29,7 +30,11 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "cweagans/composer-patches": true
+        }
     },
     "extra": {
         "patches": {

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -40,6 +40,10 @@ jobs:
           command: |
             echo "sendmail_path=/bin/true" | sudo tee -a "/etc/php.d/circleci.ini"
       - run:
+          name: Update Composer
+          command: |
+            sudo composer self-update
+      - run:
           name: Create artifacts directory
           command: mkdir /tmp/artifacts
       - run:


### PR DESCRIPTION
Starting in Composer 2.2, running `vendor/bin/the-build-installer` resulted in the following error, even when running the installer from the correct location:

> usage: dirname string [...]
> Please run this command from your project root.

This seems to be because Composer 2.2.0 included changes to the way scripts in the `vendor/bin/` directory are proxied/run, which broke the installer wrapper script. I'm not sure if there's a better way to fix this -- the updated script still assumes that scripts are located in the `vendor/bin/` directory.

* Script proxying was added in Composer 2.2.0 -- previously, scripts were symlinked into the `vendor/bin/` directory
* The environment variable `COMPOSER_BIN_DIR` was added in Composer 2.2.2
* The environment variable was changed to `COMPOSER_RUNTIME_BIN_DIR` in Composer 2.2.7

### Testing instructions

```
composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction
cd example

# Pause here and update .ddev/config.yaml to change the "name" from "drupal-skeleton" to "example"

composer require palantirnet/the-build:dev-fix-installer-dirname-error
vendor/bin/the-build-installer

# Follow the prompts to set up the site and install Drupal.
```

--> The project `example` should be set up, and ddev should be running with the installed site.

