### PR TITLE
Move phpcs configuration from the-build into a phpcs.xml file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,11 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "patches": {

--- a/defaults.yml
+++ b/defaults.yml
@@ -219,6 +219,29 @@ phplint:
   includesfile: "${build.thebuild.dir}/defaults/standard/phplint.txt"
 
 
+# Configuration for using PHP_CodeSniffer to review code according to the Drupal coding
+# standards.
+#
+# DEPRECATED - to be removed in the-build 4.2
+# This configuration is replaced by defaults/install/phpcs.xml.
+#
+# @see https://www.drupal.org/docs/develop/standards
+# @see https://github.com/squizlabs/PHP_CodeSniffer
+# @see https://www.drupal.org/project/coder
+#
+# These values are used in the defaults/build.xml template:
+#   $> phpcs --standard=${phpcs.standard} --ignore=${phpcs.ignore} ${phpcs.directories}
+phpcs:
+  # Path to a PHP_CodeSniffer standard file.
+  standard: "${build.dir}/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml"
+
+  # Space-separated list of directories to review.
+  directories: "${drupal.root}/modules/custom ${drupal.root}/themes/custom"
+
+  # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
+  extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml,js"
+
+
 # Configuration for using PHP Mess Detector to check for general PHP best practices,
 # unused variables, and to analyze complexity.
 #

--- a/defaults.yml
+++ b/defaults.yml
@@ -219,34 +219,6 @@ phplint:
   includesfile: "${build.thebuild.dir}/defaults/standard/phplint.txt"
 
 
-# Configuration for using PHP_CodeSniffer to review code according to the Drupal coding
-# standards.
-#
-# @see https://www.drupal.org/docs/develop/standards
-# @see https://github.com/squizlabs/PHP_CodeSniffer
-# @see https://www.drupal.org/project/coder
-#
-# These values are used in the defaults/build.xml template:
-#   $> phpcs --standard=${phpcs.standard} --ignore=${phpcs.ignore} ${phpcs.directories}
-phpcs:
-  # Path to a PHP_CodeSniffer standard file.
-  standard: "${build.dir}/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml"
-
-  # Space-separated list of directories to review.
-  directories: "${drupal.root}/modules/custom ${drupal.root}/themes/custom"
-
-  # Comma-separated list of patterns for files and directories to exclude from the
-  # PHP_CodeSniffer review.
-  #
-  # This is deprecated and will be removed in 3.0, and build.xml will need to be updated then to
-  # use the extensions option (below). This option should not be used with Coder >= 8.3.7, which only
-  # checks php, inc, css, and js by default.
-  ignore: "*.md"
-
-  # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
-  extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml,js"
-
-
 # Configuration for using PHP Mess Detector to check for general PHP best practices,
 # unused variables, and to analyze complexity.
 #

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -117,9 +117,8 @@
         </phplint>
 
         <!-- Run PHP Code Sniffer. -->
-        <property name="phpcs.command" value="vendor/bin/phpcs --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}" />
-        <echo msg="$> ${phpcs.command}" />
-        <exec command="${phpcs.command}" logoutput="true" checkreturn="true" />
+        <echo msg="$> vendor/bin/phpcs" />
+        <exec command="vendor/bin/phpcs" logoutput="true" checkreturn="true" />
 
         <!-- Run PHP Mess Detector. -->
         <property name="phpmd.command" value="vendor/bin/phpmd ${phpmd.directories} ${phpmd.format} ${phpmd.rulesets} --suffixes=${phpmd.suffixes}" />

--- a/defaults/install/phpcs.xml
+++ b/defaults/install/phpcs.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+
+<!--
+   @see https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml#the-annotated-sample-file
+   @see https://www.drupal.org/docs/develop/standards
+   @see https://github.com/squizlabs/PHP_CodeSniffer
+   @see https://www.drupal.org/project/coder
+   @see vendor/drupal/coder/coder_sniffer/
+-->
+
+<ruleset name="@projectname@">
+  <description>PHP_CodeSniffer configuration.</description>
+
+  <!-- Warnings and errors should throw an exception. -->
+  <config name="ignore_warnings_on_exit" value="0" />
+  <config name="ignore_errors_on_exit" value="0" />
+  <config name="installed_paths" value="vendor/drupal/coder/coder_sniffer" />
+
+  <!-- Set extensions to scan. -->
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,info,yml,css,js"/>
+
+  <!-- Use colors in output. -->
+  <arg name="colors"/>
+
+  <!-- Show progress. -->
+  <arg value="p"/>
+
+  <!-- Include existing standards. -->
+  <rule ref="Drupal"/>
+  <rule ref="DrupalPractice"/>
+
+  <!-- Directories to scan. -->
+  <file>docroot/modules/custom</file>
+  <file>docroot/themes/custom</file>
+
+  <exclude-pattern>*/behat</exclude-pattern>
+  <exclude-pattern>*/node_modules</exclude-pattern>
+  <exclude-pattern>*/vendor</exclude-pattern>
+
+</ruleset>

--- a/defaults/install/phpcs.xml
+++ b/defaults/install/phpcs.xml
@@ -14,7 +14,6 @@
   <!-- Warnings and errors should throw an exception. -->
   <config name="ignore_warnings_on_exit" value="0" />
   <config name="ignore_errors_on_exit" value="0" />
-  <config name="installed_paths" value="vendor/drupal/coder/coder_sniffer" />
 
   <!-- Set extensions to scan. -->
   <arg name="extensions" value="php,module,inc,install,test,profile,theme,info,yml,css,js"/>

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -186,6 +186,17 @@
             </filterchain>
         </copy>
 
+        <!-- Copy the phpcs.xml file template.
+             This doesn't do any property substitution except for the "projectname".
+             -->
+        <copy file="${phing.dir.install}/../defaults/install/phpcs.xml" tofile="${application.startdir}/phpcs.xml" overwrite="true">
+            <filterchain>
+                <replacetokens>
+                    <token key="projectname" value="${projectname}" />
+                </replacetokens>
+            </filterchain>
+        </copy>
+
          <!-- Copy other templates into place.
              These copy commands use <expandproperties /> for property substitution.
              -->


### PR DESCRIPTION
Alternative to #183.

This pulls out all of the phpcs config from the-build and puts it in a default `phpcs.xml` file. This should allow running the project's phpcs config by just running `phpcs` (or `vendor/bin/phpcs`) without any special arguments. It also makes it more visible to developers new to a project that phpcs is available.

This config file should probably be tested in an actual project.

If a project updates from an older version of the-build to a version that includes these changes, they would need to:
* Update the `build.xml` to use the new command
* Copy the new phpcs.xml file into the project