### PR TITLE
Remove check for Composer files in styleguide

### DIFF
--- a/targets/styleguide.xml
+++ b/targets/styleguide.xml
@@ -45,8 +45,6 @@
         <if>
             <and>
                 <available file="${styleguide.root.resolved}" type="dir" />
-                <available file="${styleguide.root.resolved}/composer.json" type="file" />
-                <available file="${styleguide.root.resolved}/composer.lock" type="file" />
                 <available file="${styleguide.root.resolved}/package.json" type="file" />
                 <available file="${styleguide.root.resolved}/yarn.lock" type="file" />
             </and>


### PR DESCRIPTION
Our [styleguide starter kit](https://github.com/palantirnet/palantir-lab) doesn't include `composer.*`, and the build looks for them by default in order to determine if the styleguide exists. Traditionally, a workaround has been to override this target in a project's `build.xml` and remove the check for those files. Going forward, it seems we no longer need the check in the-build's version of `styleguide-exists`.

The drawback to this would be for projects that update to a version of the-build with this change but still have `composer.*` in their styleguide would no longer check for the existence of those files. That doesn't seem to be an issue, unless a project was relying on the absence of `composer.*` to skip the styleguide build.