### PR TITLE
Fix php docker image name in installed circleci config

### DIFF
--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     working_directory: ~/${projectname}
     docker:
-      - image: cimg/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
       - image: cimg/mysql:5.7
         command: --max_allowed_packet=16M
         environment:


### PR DESCRIPTION
The `node-browsers` variant no longer exists, so switch to just `browsers`. If Node.js is required, use the orb:
https://circleci.com/developer/orbs/orb/circleci/node

Testing steps:
- Add the-build into a project using this branch: `composer require palantirnet/the-build:dev-fix-php-docker-image-name`
- Run the installer: `vendor/bin/the-build-installer`
- Verify the Docker image name in `.circleci/config.yml` is correct.