### PR TITLE
Fix the installer when using "other"

### DIFF
--- a/targets/install.xml
+++ b/targets/install.xml
@@ -144,7 +144,7 @@
                 <available file="${build.dir}/docroot/core" type="dir" property="drupal.root.old" value="docroot" />
 
                 <echo msg="Moving the ${drupal.root.old}/ directory to ${drupal.root}/" />
-                <exec command="rm -rf ${drupal.root}" dir="${build.dir}" checkreturn="true" logoutput="true" />
+                <exec command="rm -rf ${drupal.root}" dir="${build.dir}" />
                 <exec command="mv ${drupal.root.old} ${drupal.root}" dir="${build.dir}" checkreturn="true" logoutput="true" />
 
                 <echo msg="Editing your composer.json to install Drupal in ${drupal.root}/" />

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -60,16 +60,16 @@
              that can vary, especially around the host-specific settings.php files. -->
         <switch value="${build.host}">
             <case value="acquia">
-                <property name="drupal.root" value="docroot" />
+                <property name="drupal.root" value="docroot" override="true" />
             </case>
             <case value="pantheon">
-              <property name="drupal.root" value="web" />
+              <property name="drupal.root" value="web" override="true" />
             </case>
             <case value="platformsh">
-              <property name="drupal.root" value="web" />
+              <property name="drupal.root" value="web" override="true" />
             </case>
             <default>
-              <property name="drupal.root" value="web" />
+              <property name="drupal.root" value="web" override="true" />
             </default>
         </switch>
 

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -68,7 +68,9 @@
             <case value="platformsh">
               <property name="drupal.root" value="web" />
             </case>
-            <default />
+            <default>
+              <property name="drupal.root" value="web" />
+            </default>
         </switch>
 
         <!-- Load the defaults into the global namespace, which won't overwrite the properties the user just set. -->

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -134,16 +134,17 @@
          If the drupal.root directory doesn't exist, then we need to move it from the other location (web /
          docroot).-->
     <target name="setup-web-root" depends="set-site">
-        <available file="${build.dir}/${drupal.root}" type="dir" property="drupal.root.exists" value="true" />
+        <available file="${build.dir}/${drupal.root}/core" type="dir" property="drupal.root.exists" value="true" />
 
         <if>
             <not><equals arg1="${drupal.root.exists}" arg2="1" /></not>
             <then>
                 <!-- The one that's available is the location we're moving from. -->
-                <available file="${build.dir}/docroot" type="dir" property="drupal.root.old" value="docroot" />
-                <available file="${build.dir}/web" type="dir" property="drupal.root.old" value="web" />
+                <available file="${build.dir}/web/core" type="dir" property="drupal.root.old" value="web" />
+                <available file="${build.dir}/docroot/core" type="dir" property="drupal.root.old" value="docroot" />
 
                 <echo msg="Moving the ${drupal.root.old}/ directory to ${drupal.root}/" />
+                <exec command="rm -rf ${drupal.root}" dir="${build.dir}" checkreturn="true" logoutput="true" />
                 <exec command="mv ${drupal.root.old} ${drupal.root}" dir="${build.dir}" checkreturn="true" logoutput="true" />
 
                 <echo msg="Editing your composer.json to install Drupal in ${drupal.root}/" />

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -140,8 +140,8 @@
             <not><equals arg1="${drupal.root.exists}" arg2="1" /></not>
             <then>
                 <!-- The one that's available is the location we're moving from. -->
-                <available file="${build.dir}/web" type="dir" property="drupal.root.old" value="web" />
                 <available file="${build.dir}/docroot" type="dir" property="drupal.root.old" value="docroot" />
+                <available file="${build.dir}/web" type="dir" property="drupal.root.old" value="web" />
 
                 <echo msg="Moving the ${drupal.root.old}/ directory to ${drupal.root}/" />
                 <exec command="mv ${drupal.root.old} ${drupal.root}" dir="${build.dir}" checkreturn="true" logoutput="true" />


### PR DESCRIPTION
`drupal.root` is not set when selecting the "other" option during the-build installation. This results in the following error:

```
install > setup-web-root:

     [echo] Moving the docroot/ directory to ${drupal.root}/
sh: 1: Bad substitution
[phingcall] /var/www/html/vendor/palantirnet/the-build/targets/install.xml:137:12: /var/www/html/vendor/palantirnet/the-build/targets/install.xml:145:125: Task exited with code 2

BUILD FAILED
/var/www/html/vendor/bin/../palantirnet/the-build/targets/install.xml:86:44: Execution of the target buildfile failed. Aborting.
```

* Defines a default value for `drupal.root` during installation. The `switch` structure could be simplified, but this method leaves room for other properties to be set for each environments if needed.
* Modifies the `setup-web-root` target to check for a `core` subdirectory, because DDEV will create whatever it is configured to use as its `docroot` if it doesn't already exist, and it will add `settings.ddev.php` there. Also, we remove the new docroot before moving the old one.


### Testing

- `composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction`
- `cd example`
- `composer require --dev palantirnet/the-build:dev-fix-installer-for-other`
- Follow the instructions in https://github.com/palantirnet/drupal-skeleton#steps (starting at step 2).
- Choose "other" during the-build-installer.