### PR TITLE
explicitly disable Pantheon build step

### DIFF
--- a/defaults/install/pantheon.yml
+++ b/defaults/install/pantheon.yml
@@ -1,6 +1,8 @@
 # Pantheon configuration file
+# @see https://pantheon.io/docs/pantheon-yml
+
 api_version: 1
 web_docroot: true
-php_version: 7.4
-drush_version: 8
+php_version: 8.1
+drush_version: 11
 build_step: false

--- a/defaults/install/pantheon.yml
+++ b/defaults/install/pantheon.yml
@@ -3,3 +3,4 @@ api_version: 1
 web_docroot: true
 php_version: 7.4
 drush_version: 8
+build_step: false


### PR DESCRIPTION
Applications created on Pantheon now use an integrated Composer build: https://pantheon.io/docs/guides/integrated-composer

Since we push complete artifacts, we need to disable this build step to ensure it doesn't attempt to run against our artifact. This updates the default `pantheon.yml` that gets installed with the-build to disable the build step.