### PR TITLE
Update composer command in artifact-build target

### DIFF
--- a/targets/artifact.xml
+++ b/targets/artifact.xml
@@ -236,7 +236,7 @@
     <target name="artifact-build" hidden="true">
         <echo>Installing composer dependencies in the artifact...</echo>
         <composer command="install" composer="${composer.composer}">
-            <arg line="--no-interaction --no-dev --ignore-platform-reqs --working-dir=${artifact.directory}" />
+            <arg line="--no-interaction --no-dev --ignore-platform-reqs --prefer-install=dist --working-dir=${artifact.directory}" />
         </composer>
 
         <echo>Deleting .git subdirectories added by Composer...</echo>


### PR DESCRIPTION
When Composer runs during the artifact build process, it sometimes installs packages by cloning Git repositories instead of downloading an archived version of the release. This PR adds the `--prefer-install=dist` option to the Composer command-line in an attempt to avoid this behavior.

## To test
* Run `phing artifact`
* Verify all dependencies were installed from archives. You should see the following in the output:
`Installing drupal/module-name (version): Extracting archive`

## Open questions

This will only ensure artifact builds use `dist` packages if the version constraints are tagged releases (and the project `composer.json` has configured a package to checkout via source). We still need a more global solution for sites that require a dev version of a package, which would include `.git` directories and wouldn't be included in the `artifact-commit` process.