### PR TITLE
Update the-build to use headless chrome

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "composer-runtime-api": "^2.2.2",
         "cweagans/composer-patches": "^1.7",
+        "dmore/behat-chrome-extension": "^1.4",
         "drupal/coder": "^8.3.6",
         "drush/drush": ">=9",
         "mglaman/drupal-check": "^1.2",

--- a/defaults/install/behat.yml
+++ b/defaults/install/behat.yml
@@ -12,11 +12,13 @@ default:
   gherkin:
     cache: ~
   extensions:
-    Behat\MinkExtension:
+    DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
+    Drupal\MinkExtension:
       goutte: ~
-      selenium2:
-        wd_host: "http://127.0.0.1:8643/wd/hub"
-      javascript_session: selenium2
+      chrome:
+        api_url: "http://chrome:9222"
+      browser_name: chrome
+      javascript_session: chrome
       base_url: ${drupal.sites.default.uri}
     Drupal\DrupalExtension:
       blackbox: ~
@@ -32,5 +34,7 @@ default:
 
 circleci:
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
+      chrome:
+        api_url: "http://localhost:9222"
       base_url: ${drupal.sites.default.uri}:8000

--- a/targets/install.xml
+++ b/targets/install.xml
@@ -142,11 +142,15 @@
                 <!-- The one that's available is the location we're moving from. -->
                 <available file="${build.dir}/web/core" type="dir" property="drupal.root.old" value="web" />
                 <available file="${build.dir}/docroot/core" type="dir" property="drupal.root.old" value="docroot" />
-                <available file="${build.dir}/${drupal.root.old}/sites/default/settings.ddev.php" type="file" property="ddev_settings_exists" value="true" />
+                <available file="${build.dir}/${drupal.root}/sites/default/settings.ddev.php" type="file" property="ddev_settings_exists" value="true" />
+                <available file="${build.dir}/${drupal.root.old}/sites/default/settings.ddev.php" type="file" property="old_ddev_settings_exists" value="true" />
 
                 <!-- Copy settings.ddev.php if it doesn't exist in the old drupal root. -->
                 <if>
-                    <not><equals arg1="${ddev_settings_exists}" arg2="1" /></not>
+                    <and>
+                      <equals arg1="${ddev_settings_exists}" arg2="1" />
+                      <not><equals arg1="${old_ddev_settings_exists}" arg2="1" /></not>
+                    </and>
                     <then>
                         <echo msg="Copying settings.ddev.php to old drupal root." />
                         <exec command="cp ${drupal.root}/sites/default/settings.ddev.php ${drupal.root.old}/sites/default" dir="${build.dir}" checkreturn="true" logoutput="true" />


### PR DESCRIPTION
* Updates the installed copy of `behat.yml` to work with Headless Chrome. This is being worked on and tested with https://github.com/palantirnet/drupal-skeleton/pull/141
* Fixes an issue where The Build will not install properly when DDEV is not in use (on CircleCI, for example). The existence of `settings.ddev.php` is now checked before attempting to copy it. (See `targets/install.xml`)
* Switches from `Behat\MinkExtension` to `Drupal\MinkExtension`, which is the proper configuration according to [their documentation](https://behat-drupal-extension.readthedocs.io/en/v4.0.1/localinstall.html). This is mostly relevant when using the "wait for AJAX to finish" step. See https://github.com/jhedstrom/drupalextension/blob/93bf8cd/src/Drupal/DrupalExtension/Context/MinkContext.php#L159 and https://github.com/pantheon-systems/example-drops-8-composer/issues/400