### PR TITLE
Load headless chrome during circle builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ jobs:
           name: Run Behat tests
           command: |
             nohup php -S example.ddev.site:8000 -t $(pwd)/${DRUPAL_ROOT}/ > /tmp/artifacts/phpd.log 2>&1 &
+            google-chrome --headless --remote-debugging-port=9222 &>/dev/null &
             vendor/bin/phing test -Dbuild.env=circleci
           working_directory: ~/example
 


### PR DESCRIPTION
Fixes an issue that came up after https://github.com/palantirnet/drupal-skeleton/pull/141 was merged into the skeleton. It now uses headless Chrome, so we need to update our CircleCI config here to load the browser on the correct port.