### PR TITLE
Setup behat tests to use the drupal router

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,10 @@ jobs:
       - run:
           name: Run Behat tests
           command: |
-            nohup php -S example.ddev.site:8000 -t $(pwd)/${DRUPAL_ROOT}/ > /tmp/artifacts/phpd.log 2>&1 &
+            cd ${DRUPAL_ROOT}
+            nohup php -S example.ddev.site:8000 .ht.router.php > /tmp/artifacts/phpd.log 2>&1 &
             google-chrome --headless --remote-debugging-port=9222 &>/dev/null &
+            cd ..
             vendor/bin/phing test -Dbuild.env=circleci
           working_directory: ~/example
 

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -100,8 +100,10 @@ jobs:
       - run:
           name: Run Behat tests
           command: |
-              nohup php -S ${CIRCLE_PROJECT_REPONAME}.local:8000 -t $(pwd)/${DRUPAL_ROOT}/ > /tmp/artifacts/phpd.log 2>&1 &
+              cd ${DRUPAL_ROOT}
+              nohup php -S ${CIRCLE_PROJECT_REPONAME}.local:8000 .ht.router.php > /tmp/artifacts/phpd.log 2>&1 &
               google-chrome --headless --remote-debugging-port=9222 &>/dev/null &
+              cd ..
               vendor/bin/phing test
 
       - store_artifacts:


### PR DESCRIPTION
We just ran into this on DHS, which has some content aliased to foo-bar.htm which, it turns out, the local PHP server will not render when running 
```
    nohup php -S ${CIRCLE_PROJECT_REPONAME}.local:8000 -t $(pwd)/${DRUPAL_ROOT}/ > /tmp/artifacts/phpd.log 2>&1 &
    vendor/bin/phing behat
```

After a few hours of debugging, I accidentally found that Drupal core already solved this with .ht.router.php which says:

```
/**
 * @file
 * Router script for the built-in PHP web server.
 *
 * The built-in web server should only be used for development and testing as it
 * has a number of limitations that makes running Drupal on it highly insecure
 * and somewhat limited.
 *
 * Note that:
 * - The server is single-threaded, any requests made during the execution of
 *   the main request will hang until the main request has been completed.
 * - The web server does not enforce any of the settings in .htaccess in
 *   particular a remote user will be able to download files that normally would
 *   be protected from direct access such as .module files.
 *
 * The router script is needed to work around a bug in PHP, see
 * https://bugs.php.net/bug.php?id=61286.
 *
 * Usage:
 * php -S localhost:8888 .ht.router.php
 *
 * @see http://php.net/manual/en/features.commandline.webserver.php
 */
```
Assuming this PR – https://github.com/palantirnet/wisdhs-public/pull/561  – ever passed, we should use this approach by default.

Note that a router file must be in the directory from which the server is started, so it is not compatible with our current usage of `-t`, else we get this error:

```
Warning: require(/home/circleci/wisdhs-public/index.php): Failed to open stream: No such file or directory in /home/circleci/wisdhs-public/docroot/.ht.router.php on line 65

Fatal error: Uncaught Error: Failed opening required '/home/circleci/wisdhs-public/index.php' (include_path='.:/usr/local/lib/php') in /home/circleci/wisdhs-public/docroot/.ht.router.php:65 Stack trace: #0 {main} thrown in /home/circleci/wisdhs-public/docroot/.ht.router.php on line 65
```

## Testing steps

* The automated tests should catch these changes, since we run behat tests by default in the-build.
* 