### PR TITLE
DEV-36: The Build removed phpcbf settings

### DIFF
--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -144,9 +144,8 @@
     <!-- Target: code-fix -->
     <target name="code-fix" description="Run the automated code fixer.">
         <!-- Run PHP Code Beautifier and Fixer. -->
-        <property name="phpcbf.command" value="vendor/bin/phpcbf --standard=${phpcs.standard} --extensions=${phpcs.extensions} ${phpcs.directories}" />
-        <echo msg="$> ${phpcbf.command}" />
-        <exec command="${phpcbf.command}" logoutput="true" checkreturn="false" />
+        <echo msg="$> vendor/bin/phpcbf" />
+        <exec command="vendor/bin/phpcbf" logoutput="true" checkreturn="false" />
     </target>
 
 


### PR DESCRIPTION
[DEV-36: The Build removed phpcbf settings](https://palantir.atlassian.net/browse/DEV-36)(https://palantir.atlassian.net/browse/DEV-36)

* When we updated the phpcs command to use phpcs.xml, we left in the old config for `code-fix` (which was removed from build.yml)
* This PR runs the correct command now, since passing empty values causes the entire code base to be checked.
