### PR TITLE
Check the composer.lock file as part of code-review

### DIFF
--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -127,6 +127,9 @@
 
         <!-- Run Drupal Check. -->
         <foreach list="${drupal-check.directories}" param="drupal-check.dir" target="drupal-check" />
+
+        <!-- Ensure the composer.lock file is up to date -->
+        <exec command="composer validate --no-check-all --no-check-publish" logoutput="true" checkreturn="true" />
     </target>
 
 


### PR DESCRIPTION
Sometimes, conflicts in the `composer.lock` file may be resolved, but a developer forgets to update the hash for the file with `composer update --lock`. As a result, deployments may fail due to a dirty repository as the file is being modified when CircleCI builds the artifact.

This pull request adds a check to the `code-review` step to see if the `composer.lock` file is up to date.