### PR TITLE
Add config_ignore during drupal-first-install

### DIFF
--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -274,6 +274,7 @@ Or, you can specify the export file directly:
 
         <composer command="require" composer="${composer.composer}">
             <arg value="drupal/admin_toolbar" />
+            <arg value="drupal/config_ignore" />
             <arg value="drupal/config_split" />
             <arg value="drupal/devel" />
             <arg value="drupal/workbench" />


### PR DESCRIPTION
Config Ignore was added to the skeleton in https://github.com/palantirnet/drupal-skeleton/pull/110.

Add it to the-build first Drupal install task for consistency. Also, contrib modules could be removed from the skeleton `composer.json` as shown in https://github.com/palantirnet/drupal-skeleton/pull/138