### PR TITLE
DEV-45: Prevent 404 in the-build-installer by updating acquia memcache install task

### DIFF
--- a/targets/install.xml
+++ b/targets/install.xml
@@ -280,7 +280,10 @@
             <case value="acquia">
                 <!-- Site-level setup -->
                 <!-- @see https://docs.acquia.com/cloud-platform/performance/memcached/enable/ -->
-                <httpget url="https://docs.acquia.com/_downloads/cloud-memcache-d8+.php" dir="${build.dir}/${drupal.root}/sites/${drupal.site.dir}" filename="settings.acquia-memcache.php"/>
+                <composer command="require" composer="${composer.composer}">
+                    <arg line="--working-dir ${application.startdir}"/>
+                    <arg value="drupal/memcache"/>
+                </composer>
             </case>
 
             <case value="pantheon">


### PR DESCRIPTION
User story: [DEV-45: 404 error on install in request for Acquia memcache config file](https://palantir.atlassian.net/browse/DEV-45)

### Description

This PR updates the process for adding memcache to an acquia project based on https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later
* Update the steps taken for acquia-hosted projects to add a composer dependency instead of making a HTTP request for an acquia-provided settings file per https://docs.acquia.com/cloud-platform/performance/memcached/enable/#configuration-for-drupal-9-or-later

### Test Steps
Test in https://github.com/palantirnet/drupal-skeleton/pull/149 which points to this branch in is composer.json for `the-build`