### PR TITLE
DEV-41 - Pin circle php image to 8.1.18.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     working_directory: ~/project
     docker:
-      - image: cimg/php:8.1-browsers
+      - image: cimg/php:8.1.18-browsers
       - image: cimg/mysql:5.7
         command: --max_allowed_packet=16M
         environment:


### PR DESCRIPTION
Pin circle php image to 8.1.18 to deal with phpcs out of memory bug on 8.1.19. 

https://palantir.atlassian.net/browse/DEV-41