### PR TITLE
DEV-42 - Drop database tables when running load-db.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "pear/http_request2": "^2.3",
         "pear/versioncontrol_git": "@dev",
         "phing/phing": "^2.14",
-        "phpmd/phpmd": "^2.4",
+        "phpmd/phpmd": "2.13",
         "phpspec/prophecy-phpunit": "^2"
     },
     "autoload": {

--- a/defaults.yml
+++ b/defaults.yml
@@ -144,6 +144,10 @@ drupal:
         #   $> phing load-db -Ddb.load.file=artifacts/foo.sql.gz
         #file:
 
+      drop_db:
+        # Command to drop the database tables.
+        mysql_command: drush sql-drop
+
 
 # Configuration for targets/artifact.xml
 artifact:

--- a/defaults.yml
+++ b/defaults.yml
@@ -146,7 +146,7 @@ drupal:
 
       drop_db:
         # Command to drop the database tables.
-        mysql_command: drush sql-drop
+        mysql_command: drush sql-drop -y
 
 
 # Configuration for targets/artifact.xml

--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -170,6 +170,11 @@ Or, you can specify the export file directly:
           </then>
         </if>
 
+        <!-- Drop the database tables. -->
+        <property name="drupal.site.drop_db.command" value="${drupal.site.drop_db.mysql_command}" />
+        <echo>$> ${drupal.site.drop_db.command}</echo>
+        <exec dir="${build.dir}" command="${drupal.site.drop_db.command}" checkreturn="true" logoutput="true" />
+
         <!-- Load the contents of the file into Drupal -->
         <property name="drupal.site.load_db.command" value="${drupal.site.load_db.contents_command} ${drupal.site.load_db.file} | ${drupal.site.load_db.mysql_command}" />
         <echo>$> ${drupal.site.load_db.command}</echo>


### PR DESCRIPTION
This work drops the database tables when running `drupal-load-db`. 

### Testing Instructions

1. In a project checkout this branch for the-build `"palantirnet/the-build": "dev-dev-42-drupal-load-db"`
2. `composer up palantirnet/the-build`
3. SSH into ddev `ddev ssh`
4. Run `phing load` and verify that `drupal-load-db` runs `drush sql-drop -y`