### PR TITLE
unpin phpmd version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,13 @@ jobs:
             echo "phpcs for modules"
             vendor/bin/phpcs defaults/standard/modules --standard="Drupal,DrupalPractice" -n --extensions="php,module,inc,install,test,profile,theme"
             echo "phpmd for modules"
-            vendor/bin/phpmd defaults/standard/modules text defaults/standard/phpmd.xml "php,inc,module,theme,profile,install,test"
+            vendor/bin/phpmd defaults/standard/modules text defaults/standard/phpmd.xml --suffixes php,inc,module,theme,profile,install,test
             echo "phpstan for modules"
             vendor/bin/phpstan analyse defaults/standard/modules --level=2
             echo "phpcs for tasks"
             vendor/bin/phpcs src --standard="Drupal,DrupalPractice" -n --extensions="php,module,inc,install,test,profile,theme"
             echo "phpmd for tasks"
-            vendor/bin/phpmd src text defaults/standard/phpmd.xml "php,inc,module,theme,profile,install,test"
+            vendor/bin/phpmd src text defaults/standard/phpmd.xml --suffixes php,inc,module,theme,profile,install,test
             echo "phpstan for tasks"
             vendor/bin/phpstan analyse src --level=2
 

--- a/code-review.sh
+++ b/code-review.sh
@@ -9,7 +9,7 @@ echo "-------------"
 vendor/bin/phpcs defaults/standard/modules --standard="Drupal,DrupalPractice" -n --extensions="php,module,inc,install,test,profile,theme"
 echo "Running PHPMD on modules"
 echo "-------------"
-vendor/bin/phpmd defaults/standard/modules text defaults/standard/phpmd.xml "php,inc,module,theme,profile,install,test"
+vendor/bin/phpmd defaults/standard/modules text defaults/standard/phpmd.xml --suffixes php,inc,module,theme,profile,install,test
 echo "Running PHPStan on modules"
 echo "---------------"
 vendor/bin/phpstan analyse defaults/standard/modules --level=2
@@ -24,7 +24,7 @@ echo "-------------"
 vendor/bin/phpcs src --standard="Drupal,DrupalPractice" -n --extensions="php,module,inc,install,test,profile,theme"
 echo "Running PHPMD on tasks"
 echo "-------------"
-vendor/bin/phpmd src text defaults/standard/phpmd.xml "php,inc,module,theme,profile,install,test"
+vendor/bin/phpmd src text defaults/standard/phpmd.xml --suffixes php,inc,module,theme,profile,install,test
 echo "Running PHPStan on tasks"
 echo "---------------"
 vendor/bin/phpstan analyse src --level=2

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "pear/http_request2": "^2.3",
         "pear/versioncontrol_git": "@dev",
         "phing/phing": "^2.14",
-        "phpmd/phpmd": "2.13",
+        "phpmd/phpmd": "^2.13",
         "phpspec/prophecy-phpunit": "^2"
     },
     "autoload": {

--- a/defaults.yml
+++ b/defaults.yml
@@ -252,7 +252,7 @@ phpcs:
 # @see https://phpmd.org/
 #
 # These values are used in the defaults/build.xml template:
-#   $> phpmd ${phpmd.directories} ${phpmd.format} ${phpmd.rulesets} --suffixes=${phpmd.suffixes}
+#   $> phpmd ${phpmd.directories} ${phpmd.format} ${phpmd.rulesets} --suffixes ${phpmd.suffixes}
 phpmd:
   # Comma-separated list of directories to review.
   directories: "${drupal.root}/modules/custom/,${drupal.root}/themes/custom/"

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -121,7 +121,7 @@
         <exec command="vendor/bin/phpcs" logoutput="true" checkreturn="true" />
 
         <!-- Run PHP Mess Detector. -->
-        <property name="phpmd.command" value="vendor/bin/phpmd ${phpmd.directories} ${phpmd.format} ${phpmd.rulesets} --suffixes=${phpmd.suffixes}" />
+        <property name="phpmd.command" value="vendor/bin/phpmd ${phpmd.directories} ${phpmd.format} ${phpmd.rulesets} --suffixes ${phpmd.suffixes}" />
         <echo msg="$> ${phpmd.command}" />
         <exec command="${phpmd.command}" logoutput="true" checkreturn="true" />
 


### PR DESCRIPTION
Versions of phpmd greater than 2.13 require the `--suffixes` flag. We pinned to 2.13 until we figured this out. This removes the constraint and allows 2.14 and later to be installed while fixing the calls to `phpmd` in the-build.