### PR TITLE
DEV-49: Add behat features directory to phpcs linting.

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -24,7 +24,7 @@ drupal:
   #root: web
 
   # Comma-separated list of directories that should be present for Drupal development.
-  create_dirs: "${drupal.root}/modules/custom,${drupal.root}/themes/custom,config/config_split/development,config/config_split/staging,config/config_split/production"
+  create_dirs: "${drupal.root}/modules/custom,${drupal.root}/themes/custom,config/config_split/development,config/config_split/staging,config/config_split/production,features/bootsrap,features/screenshots"
 
   twig:
     # Whether to enable twig debugging.

--- a/defaults.yml
+++ b/defaults.yml
@@ -24,7 +24,7 @@ drupal:
   #root: web
 
   # Comma-separated list of directories that should be present for Drupal development.
-  create_dirs: "${drupal.root}/modules/custom,${drupal.root}/themes/custom,config/config_split/development,config/config_split/staging,config/config_split/production,features/bootsrap,features/screenshots"
+  create_dirs: "${drupal.root}/modules/custom,${drupal.root}/themes/custom,config/config_split/development,config/config_split/staging,config/config_split/production,features/screenshots"
 
   twig:
     # Whether to enable twig debugging.

--- a/defaults/install/phpcs.xml
+++ b/defaults/install/phpcs.xml
@@ -31,6 +31,7 @@
   <!-- Directories to scan. -->
   <file>@webroot@/modules/custom</file>
   <file>@webroot@/themes/custom</file>
+  <file>@webroot@/features/bootstrap</file>
 
   <exclude-pattern>*/behat</exclude-pattern>
   <exclude-pattern>*/node_modules</exclude-pattern>

--- a/defaults/install/phpcs.xml
+++ b/defaults/install/phpcs.xml
@@ -31,7 +31,7 @@
   <!-- Directories to scan. -->
   <file>@webroot@/modules/custom</file>
   <file>@webroot@/themes/custom</file>
-  <file>/features/bootstrap</file>
+  <file>features/bootstrap</file>
 
   <exclude-pattern>*/behat</exclude-pattern>
   <exclude-pattern>*/node_modules</exclude-pattern>

--- a/defaults/install/phpcs.xml
+++ b/defaults/install/phpcs.xml
@@ -31,7 +31,7 @@
   <!-- Directories to scan. -->
   <file>@webroot@/modules/custom</file>
   <file>@webroot@/themes/custom</file>
-  <file>@webroot@/features/bootstrap</file>
+  <file>/features/bootstrap</file>
 
   <exclude-pattern>*/behat</exclude-pattern>
   <exclude-pattern>*/node_modules</exclude-pattern>


### PR DESCRIPTION
Adds features/bootstrap to the list of directories to be scanned so we can test the code in our custom contexts.
 
Testing: 
Spin up a site that has behat testing set up
composer require this version of the_build
run `ddev phing code-review` and verify that the test scans the features directory.  

This addresses both https://palantir.atlassian.net/browse/DEV-56 and https://palantir.atlassian.net/browse/DEV-49.