### PR TITLE
DEV-70: Update install node dependencies task in the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       # Create a new project using the drupal-skeleton project
       - run:
           name: Create a new Drupal project
-          command: composer create-project palantirnet/drupal-skeleton example dev-DEV-70-update-install-node-dependencies-task-in-the-build --no-interaction
+          command: composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction
           working_directory: ~/
 
       # Use this copy of the-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       # Create a new project using the drupal-skeleton project
       - run:
           name: Create a new Drupal project
-          command: composer create-project palantirnet/drupal-skeleton example dev-develop --no-interaction
+          command: composer create-project palantirnet/drupal-skeleton example dev-DEV-70-update-install-node-dependencies-task-in-the-build --no-interaction
           working_directory: ~/
 
       # Use this copy of the-build

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -50,10 +50,11 @@ jobs:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
 
-      # Composer package cache
+      # Package cache
       - restore_cache:
           keys:
-            - composer-v1-
+            - package-cache-v1-
+
       # Source cache
       - restore_cache:
           keys:
@@ -64,15 +65,19 @@ jobs:
       - run:
           name: Composer install
           command: composer install --no-interaction --prefer-dist
+      - run:
+          name: Yarn install
+          command: yarn install
 
-      # Composer package cache - update when the contents of the Composer cache directory
-      # change
-      - run: ls -1R ~/.cache/composer/ > /tmp/composer-cache.txt
+      # Package cache. This is updated when the contents of the ~/.cache directory change.
+      # Both Composer and Yarn use this directory.
+      - run: ls -1R ~/.cache/ > /tmp/package-cache.txt
       - save_cache:
-          key: composer-v1-{{ checksum "/tmp/composer-cache.txt" }}
+          key: package-cache-v1-{{ checksum "/tmp/package-cache.txt" }}
           paths:
-              - ~/.cache/composer
-      # Source cache - update when branch changes
+              - ~/.cache
+
+      # Source cache. This is updated for each different branch.
       - save_cache:
           key: source-v1-{{ .Branch }}
           paths:

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -173,17 +173,6 @@
                 <exec dir="${drupal.root}/.." command="yarn install" logoutput="true" />
             </then>
         </if>
-        <echo msg="Seeing if Drupal core npm packages are installed and at the expected version." />
-        <exec dir="${drupal.root}/core" command="yarn install --check-files --verbose" returnProperty="core_dependencies"  logoutput="true" />
-        <if>
-            <not>
-                <equals arg1="${core_dependencies}" arg2="0" />
-            </not>
-            <then>
-                <echo msg="Install Core node dependencies to get eslint libraries." />
-                <exec dir="${drupal.root}/core" command="yarn install" logoutput="true" checkreturn="true" />
-            </then>
-        </if>
     </target>
 
 

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -149,7 +149,7 @@
     <target name="eslint" depends="install-node-dependencies">
         <!-- Lint custom module and theme (by default) javascript. -->
         <echo msg="$> yarn run eslint --ext ${eslint.extensions} ${eslint.directory}" />
-        <exec command="yarn run eslint --fix-dry-run --ext ${eslint.extensions} --resolve-plugins-relative-to ${drupal.root}/core --no-error-on-unmatched-pattern ${eslint.directory}" logoutput="true" checkreturn="true" />
+        <exec command="yarn run eslint --fix-dry-run --ext ${eslint.extensions} --no-error-on-unmatched-pattern ${eslint.directory}" logoutput="true" checkreturn="true" />
     </target>
 
 

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -162,17 +162,8 @@
 
     <!-- Target: install-node-dependencies -->
     <target name="install-node-dependencies" depends="" description="Install project, core, and custom module node dependencies">
-        <echo msg="Seeing if project npm packages are installed and at the expected version." />
-        <exec command="yarn install --check-files --verbose" returnProperty="project_dependencies"  logoutput="true" />
-        <if>
-            <not>
-                <equals arg1="${project_dependencies}" arg2="0" />
-            </not>
-            <then>
-                <echo msg="Install project node dependencies to get eslint libraries." />
-                <exec dir="${drupal.root}/.." command="yarn install" logoutput="true" />
-            </then>
-        </if>
+        <echo msg="Install project node dependencies to get eslint libraries." />
+        <exec dir="${drupal.root}/.." command="yarn install" logoutput="true" />
     </target>
 
 


### PR DESCRIPTION
- removes test for installed dependencies, as Yarn already does that
- removes call to install dependencies within Drupal core directory
- removes option to resolve dependencies relative to Drupal core directory

This has a [companion PR](https://github.com/palantirnet/drupal-skeleton/pull/160) for drupal-skeleton, which adds the required dependencies to the project `package.json`. Tests passed on CircleCI, and the change to use that version of the skeleton was reverted: https://app.circleci.com/pipelines/github/palantirnet/the-build/589/workflows/fced6b6f-4a86-4e1a-8728-fd3610a1d741/jobs/600

See testing steps on the companion PR.