### PR TITLE
Remove unused variables related to phpcs

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -213,29 +213,6 @@ phplint:
   includesfile: "${build.thebuild.dir}/defaults/standard/phplint.txt"
 
 
-# Configuration for using PHP_CodeSniffer to review code according to the Drupal coding
-# standards.
-#
-# DEPRECATED - to be removed in the-build 4.2
-# This configuration is replaced by defaults/install/phpcs.xml.
-#
-# @see https://www.drupal.org/docs/develop/standards
-# @see https://github.com/squizlabs/PHP_CodeSniffer
-# @see https://www.drupal.org/project/coder
-#
-# These values are used in the defaults/build.xml template:
-#   $> phpcs --standard=${phpcs.standard} --ignore=${phpcs.ignore} ${phpcs.directories}
-phpcs:
-  # Path to a PHP_CodeSniffer standard file.
-  standard: "${build.dir}/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml"
-
-  # Space-separated list of directories to review.
-  directories: "${drupal.root}/modules/custom ${drupal.root}/themes/custom"
-
-  # Comma-separated list of extensions to check in the PHP_CodeSniffer review.
-  extensions: "php,module,inc,install,test,profile,theme,css,info,txt,yml,js"
-
-
 # Configuration for using PHP Mess Detector to check for general PHP best practices,
 # unused variables, and to analyze complexity.
 #


### PR DESCRIPTION
This PR removes all phpcs config variables from `defaults.yml`, because as of the-build 4.0.0, phpcs config was moved to phpcs.xml (see defaults/install/phpcs.xml), and phing variables are no longer used when running it.

Given that 4.0 was released close to 2 years ago (https://github.com/palantirnet/the-build/releases/tag/4.0.0), if anyone is still using a 3.x version of the-build, a full reinstall is the best way to get the latest configuration and features.

refs https://palantir.atlassian.net/browse/DEV-27