### PR TITLE
Add FailAid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "dmore/behat-chrome-extension": "^1.4",
         "drupal/coder": "^8.3.6",
         "drush/drush": "^13",
+        "genesis/behat-fail-aid": "^3.7",
         "mglaman/drupal-check": "^1.5",
         "palantirnet/phing-drush-task": "^1.1",
         "pear/http_request2": "^2.3",

--- a/defaults.yml
+++ b/defaults.yml
@@ -28,7 +28,7 @@ drupal:
   #root: web
 
   # Comma-separated list of directories that should be present for Drupal development.
-  create_dirs: "${drupal.root}/modules/custom,${drupal.root}/themes/custom,config/config_split/development,config/config_split/staging,config/config_split/production,features/FailAid_screenshots"
+  create_dirs: "${drupal.root}/modules/custom,${drupal.root}/themes/custom,config/config_split/development,config/config_split/staging,config/config_split/production,artifacts/FailAid_screenshots"
 
   twig:
     # Whether to enable twig debugging.

--- a/defaults.yml
+++ b/defaults.yml
@@ -28,7 +28,7 @@ drupal:
   #root: web
 
   # Comma-separated list of directories that should be present for Drupal development.
-  create_dirs: "${drupal.root}/modules/custom,${drupal.root}/themes/custom,config/config_split/development,config/config_split/staging,config/config_split/production,features/screenshots"
+  create_dirs: "${drupal.root}/modules/custom,${drupal.root}/themes/custom,config/config_split/development,config/config_split/staging,config/config_split/production,features/FailAid_screenshots"
 
   twig:
     # Whether to enable twig debugging.

--- a/defaults/install/.circleci/config.yml
+++ b/defaults/install/.circleci/config.yml
@@ -47,6 +47,9 @@ jobs:
           name: Create artifacts directory
           command: mkdir /tmp/artifacts
       - run:
+          name: Create directory for Behat test failure screenshots
+          command: mkdir /tmp/artifacts/FailAid_screenshots
+      - run:
           name: Configure URL in /etc/hosts
           command: echo 127.0.0.1 ${CIRCLE_PROJECT_REPONAME}.local | sudo tee -a /etc/hosts
 

--- a/defaults/install/behat.yml
+++ b/defaults/install/behat.yml
@@ -7,6 +7,7 @@ default:
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
+        - FailAid\Context\FailureContext
       filters:
         tags: "~@skipci"
   gherkin:
@@ -31,6 +32,12 @@ default:
         log_out: 'Log out'
       region_map:
         anywhere: "*"
+    FailAid\Extension:
+      screenshot:
+        directory: /var/www/html/features/FailAid_screenshots/
+        mode: default
+        autoClean: false
+        size: 1440x1280
 
 circleci:
   extensions:
@@ -38,3 +45,6 @@ circleci:
       chrome:
         api_url: "http://localhost:9222"
       base_url: ${drupal.sites.default.uri}:8000
+    FailAid\Extension:
+      screenshot:
+        directory: /tmp/artifacts/FailAid_screenshots/

--- a/defaults/install/behat.yml
+++ b/defaults/install/behat.yml
@@ -34,7 +34,7 @@ default:
         anywhere: "*"
     FailAid\Extension:
       screenshot:
-        directory: /var/www/html/features/FailAid_screenshots/
+        directory: /var/www/html/artifacts/FailAid_screenshots/
         mode: default
         autoClean: false
         size: 1440x1280


### PR DESCRIPTION
https://palantir.atlassian.net/browse/DEV-52

Add FailAid, which saves screenshots when a Behat test fails.

Testing:

1. In a bare drupal-skeleton project...
2. `composer require --dev palantirnet/the-build:dev-DEV-52-failaid`
3. `vendor/bin/the-build-installer`
4. `phing build`
5. Now the directory `artifacts/FailAid_screenshots` should exist
6. `ddev start`
7. `phing install -Ddrupal.validate_clean_config.bypass=yes`
8. `ddev exec behat`
9. All tests should pass as usual
10. Edit the `features/installation.feature` sample test and add the line `And I should see the link "Doesn't exist"`
11. `ddev exec behat`
12. There should now be HTML output from FailAid in `artifacts/FailAid_screenshots`
