### PR TITLE
Experimental: Provide templated files via drupal-scaffold

### DIFF
--- a/assets/behat.yml
+++ b/assets/behat.yml
@@ -19,7 +19,7 @@ default:
         api_url: "http://chrome:9222"
       browser_name: chrome
       javascript_session: chrome
-      base_url: PLACEHOLDER_URI
+      base_url: PLACEHOLDER_URL
     Drupal\DrupalExtension:
       blackbox: ~
       api_driver: 'drupal'
@@ -37,4 +37,4 @@ circleci:
     Drupal\MinkExtension:
       chrome:
         api_url: "http://localhost:9222"
-      base_url: PLACEHOLDER_URI:8000
+      base_url: PLACEHOLDER_URL:8000

--- a/assets/substitutions.json
+++ b/assets/substitutions.json
@@ -1,0 +1,4 @@
+{
+  "PLACEHOLDER_URL": "https://drupal-skeleton.ddev.site",
+  "PLACEHOLDER_DRUPAL_ROOT": "docroot"
+}

--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,10 @@
         "drupal-scaffold": {
             "file-mapping": {
                 "[project-root]/behat.yml": "defaults/install/behat.yml",
-                "[project-root]/.circleci/config.yml": "defaults/.circleci/config.yml",
-                "[project-root]/build.xml": "defaults/build.xml",
-                "[project-root]/phpcs.xml": "defaults/phpcs.xml",
-                "[project-root]/phpmd.xml": "defaults/phpmd.xml"
+                "[project-root]/.circleci/config.yml": "defaults/install/.circleci/config.yml",
+                "[project-root]/build.xml": "defaults/install/build.xml",
+                "[project-root]/phpcs.xml": "defaults/install/phpcs.xml",
+                "[project-root]/phpmd.xml": "defaults/install/phpmd.xml"
             }
         },
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,11 @@
         }
     },
     "extra": {
+        "drupal-scaffold": {
+            "file-mapping": {
+                "[project-root]/behat.yml": "defaults/install/behat.yml"
+            }
+        },
         "patches": {
             "phing/phing": {
                 "Support relative symliks in Phing": "https://raw.githubusercontent.com/palantirnet/the-build/7cdc28b6019fb88a0604261366f9ea35f1e21d96/patches/phing-relative-symlinks.patch"

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "phpspec/prophecy-phpunit": "^2"
     },
     "autoload": {
-        "psr-0": {
-            "TheBuild\\": "src/"
+        "psr-4": {
+            "TheBuild\\": "src/TheBuild/"
         }
     },
     "config": {
@@ -41,7 +41,11 @@
     "extra": {
         "drupal-scaffold": {
             "file-mapping": {
-                "[project-root]/behat.yml": "defaults/install/behat.yml"
+                "[project-root]/behat.yml": "defaults/install/behat.yml",
+                "[project-root]/.circleci/config.yml": "defaults/.circleci/config.yml",
+                "[project-root]/build.xml": "defaults/build.xml",
+                "[project-root]/phpcs.xml": "defaults/phpcs.xml",
+                "[project-root]/phpmd.xml": "defaults/phpmd.xml"
             }
         },
         "patches": {
@@ -49,5 +53,10 @@
                 "Support relative symliks in Phing": "https://raw.githubusercontent.com/palantirnet/the-build/7cdc28b6019fb88a0604261366f9ea35f1e21d96/patches/phing-relative-symlinks.patch"
             }
         }
+    },
+    "scripts": {
+        "post-drupal-scaffold-cmd": [
+            "TheBuild\\Rewrite::replacePlaceholder"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -58,5 +58,8 @@
         "post-drupal-scaffold-cmd": [
             "TheBuild\\Rewrite::replacePlaceholder"
         ]
+    },
+    "require-dev": {
+        "composer/composer": "^2.8"
     }
 }

--- a/defaults/install/build.xml
+++ b/defaults/install/build.xml
@@ -10,7 +10,7 @@
   @see https://github.com/palantirnet/the-build
   -->
 
-<project name="@projectname@" default="list">
+<project name="PLACEHOLDER_PROJECT_NAME" default="list">
 
     <!-- Add property loading and targets from palantirnet/the-build. -->
     <import file="vendor/palantirnet/the-build/targets/the-build.xml" />
@@ -170,7 +170,7 @@
     <!-- Target: artifact -->
     <target name="artifact" description="Build and deploy the application.">
         <phing phingfile="build.xml" target="artifact-main" inheritAll="false" haltonfailure="true">
-            <property name="build.env" value="@host@" />
+            <property name="build.env" value="PLACEHOLDER_HOST" />
         </phing>
     </target>
 

--- a/defaults/install/drush/sites/projectname.site.yml
+++ b/defaults/install/drush/sites/projectname.site.yml
@@ -1,2 +1,2 @@
 local:
-  uri: '@uri@'
+  uri: 'PLACEHOLDER_URI'

--- a/defaults/install/phpcs.xml
+++ b/defaults/install/phpcs.xml
@@ -8,7 +8,7 @@
    @see vendor/drupal/coder/coder_sniffer/
 -->
 
-<ruleset name="@projectname@">
+<ruleset name="PLACEHOLDER_PROJECT_NAME">
   <description>PHP_CodeSniffer configuration.</description>
 
   <!-- Warnings and errors should throw an exception. -->
@@ -29,8 +29,8 @@
   <rule ref="DrupalPractice"/>
 
   <!-- Directories to scan. -->
-  <file>@webroot@/modules/custom</file>
-  <file>@webroot@/themes/custom</file>
+  <file>PLACEHOLDER_DRUPAL_ROOT/modules/custom</file>
+  <file>PLACEHOLDER_DRUPAL_ROOT/themes/custom</file>
   <file>features/bootstrap</file>
 
   <exclude-pattern>*/behat</exclude-pattern>

--- a/src/TheBuild/Rewrite.php
+++ b/src/TheBuild/Rewrite.php
@@ -16,7 +16,7 @@ class Rewrite {
     $io = $event->getIO();
 
     $substitutions = self::getSubstitutions($event);
-    $io->write("<info>JSON data: " . print_r($substitutions, TRUE) . "</info>");
+    $io->write("<info>Using replacements: " . print_r($substitutions, TRUE) . "</info>");
 
     $files = self::getFiles($event);
     foreach ($files as $file) {

--- a/src/TheBuild/Rewrite.php
+++ b/src/TheBuild/Rewrite.php
@@ -54,7 +54,8 @@ class Rewrite {
   }
 
   protected static function getFiles($event) {
-    $fileMapping = $event->getComposer()->getPackage()->getExtra()['drupal-scaffold']['file-mapping'];
+    $package = $event->getComposer()->getRepositoryManager()->getLocalRepository()->findPackage('palantirnet/the-build', '*');
+    $fileMapping = $package->getExtra()['drupal-scaffold']['file-mapping'];
 
     $substitutions = self::getSubstitutions($event);
     $file_substitutions = [

--- a/src/TheBuild/Rewrite.php
+++ b/src/TheBuild/Rewrite.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace TheBuild;
+
+use Composer\Script\Event;
+
+/**
+ * Rewrite placeholders in files.
+ */
+class Rewrite {
+
+  /**
+   * Rewrite placeholders in scaffolding files.
+   */
+  public static function replacePlaceholder(Event $event) {
+    $io = $event->getIO();
+
+    $substitutions = self::getSubstitutions($event);
+    $io->write("<info>JSON data: " . print_r($substitutions, TRUE) . "</info>");
+
+    $files = self::getFiles($event);
+    foreach ($files as $file) {
+      $io->write("<info>Updating file: " . $file . "</info>");
+
+      if (!file_exists($file)) {
+        $io->write("<info>File not found: " . $file . "</info>");
+        continue;
+      }
+
+      try {
+        $contents = file_get_contents($file);
+        $contents = str_replace(array_keys($substitutions), array_values($substitutions), $contents);
+        file_put_contents($file, $contents);
+      }
+      catch (\Exception $e) {
+        $io->error($e->getMessage());
+        // Error.
+        return 1;
+      }
+    }
+  }
+
+  protected static function getSubstitutions($event) {
+    $substitutions = [
+      'PLACEHOLDER_DRUPAL_ROOT' => $event->getComposer()->getPackage()->getExtra()['drupal-scaffold']['locations']['web-root'],
+      'PLACEHOLDER_PROJECT_ROOT' => $event->getComposer()->getConfig()->get('vendor-dir') . '/../',
+      'PLACEHOLDER_PROJECT_NAME' => explode('/', $event->getComposer()->getPackage()->getName())[1],
+      'PLACEHOLDER_HOST' => 'acquia',
+    ];
+
+    $substitutions['PLACEHOLDER_URL'] = "https://{$substitutions['PLACEHOLDER_PROJECT_NAME']}.ddev.site";
+
+    return $substitutions;
+  }
+
+  protected static function getFiles($event) {
+    $fileMapping = $event->getComposer()->getPackage()->getExtra()['drupal-scaffold']['file-mapping'];
+
+    $substitutions = self::getSubstitutions($event);
+    $file_substitutions = [
+      '[web-root]' => $substitutions['PLACEHOLDER_DRUPAL_ROOT'],
+      '[project-root]' => $substitutions['PLACEHOLDER_PROJECT_ROOT'],
+    ];
+
+    $files = [];
+    foreach ($fileMapping as $file => $source) {
+      $files[] = str_replace(array_keys($file_substitutions), array_values($file_substitutions), $file);
+    }
+
+    return $files;
+  }
+
+}


### PR DESCRIPTION
Uses drupal/core-composer-scaffold to declare and copy scaffolding files into the project. The goal here is to rip out a bunch of the phing installer stuff, as it's complicated and for the file scaffolding at least, doesn't add much.

Example use:
```
composer create-project palantirnet/drupal-skeleton example
cd example
composer require palantirnet/the-build:dev-experimental-drupal-scaffold
```

This will set up a bunch of the scaffolding files from the-build immediately (without running `vendor/bin/the-build-installer`). There's a script that is supposed to run after scaffolding that replaces placeholders in those files.

* This doesn't cover all the templated files, just some of them so far
* The script that is supposed to replace placeholders doesn't seem to run unless I also put it into the root composer.json file
* The placeholder replacement script really shouldn't run until after you've updated your project name and webroot in the root composer.json file anyway. If you change those you'd need to run `composer drupal:scaffold` to refresh the scaffolding files.
