### PR TITLE
Don't check .env files into artifacts

### DIFF
--- a/defaults/artifact/gitignore
+++ b/defaults/artifact/gitignore
@@ -1,3 +1,4 @@
 # This .gitignore file is specific to the artifact.
 settings.local.php
 node_modules
+.env


### PR DESCRIPTION
`.env` files often contain sensitive keys or secrets used by environments. Don't check these into artifact builds if they exist on local dev environments during `phing artifact`.