### PR TITLE
Fix sql-query argument escaping for Drush 13 compatibility

### DIFF
--- a/targets/drupal.xml
+++ b/targets/drupal.xml
@@ -199,7 +199,7 @@ Or, you can specify the export file directly:
                 <not><isset property="env.IS_DDEV_PROJECT" /></not>
             </and>
             <then>
-                <property name="test_query" override="true">\"SELECT 1\"</property>
+                <property name="test_query" override="true">SELECT 1</property>
             </then>
         </if>
 


### PR DESCRIPTION
Fix sql-query argument escaping for Drush 13 compatibility

The drupal-has-database-connection target checks for a working DB connection by running drush sql-query with a trivial SELECT 1. The target sets test_query to SELECT 1 by default, but there's an <if> block that overrides it when all three conditions are true:

1. .ddev/config.yaml exists in the project
2. ddev is installed on the host (which ddev returns 0)
3. The IS_DDEV_PROJECT env var is not set (meaning you're running Phing from the host machine, not inside the container)

In that scenario, drush runs through ddev drush. In Drush 12, the query argument needed to survive an extra shell-escaping hop through the ddev proxy, so wrapping it in \"...\" kept it intact. In *** Drush 13 ***, argument handling changed — passing \"SELECT 1\" causes Drush to literally include the double-quote characters in the SQL, which causes the query to fail. Removing the extra quoting fixes it for Drush 13 (and the plain SELECT 1 was already working fine on all other paths).
